### PR TITLE
feat: brand qatlami — Case Studies (Faza 1)

### DIFF
--- a/src/app/[lang]/case-studies/[slug]/page.tsx
+++ b/src/app/[lang]/case-studies/[slug]/page.tsx
@@ -1,0 +1,31 @@
+import { notFound } from "next/navigation";
+import CaseStudyView from "~/components/case-study/case-study-view";
+import { getCaseStudyBySlug, getAllCaseStudySlugs } from "~/lib/case-studies";
+import { Lang } from "~/types";
+
+export const dynamicParams = false;
+
+export async function generateStaticParams() {
+  const langs: Lang[] = ["uz", "ru", "en"];
+  const out: { lang: string; slug: string }[] = [];
+  for (const lang of langs) {
+    for (const slug of await getAllCaseStudySlugs(lang)) out.push({ lang, slug });
+  }
+  return out;
+}
+
+export async function generateMetadata({ params }: { params: { lang: string; slug: string } }) {
+  const project = await getCaseStudyBySlug(params.lang as Lang, params.slug);
+  if (!project) return {};
+  return {
+    title: `${project.title} — Case Study | Madrimov Xudoshukur`,
+    description: project.caseStudy!.problem,
+  };
+}
+
+export default async function Page({ params }: { params: { lang: string; slug: string } }) {
+  const lang = params.lang as Lang;
+  const project = await getCaseStudyBySlug(lang, params.slug);
+  if (!project) notFound();
+  return <CaseStudyView lang={lang} project={project} />;
+}

--- a/src/app/[lang]/case-studies/page.tsx
+++ b/src/app/[lang]/case-studies/page.tsx
@@ -1,0 +1,28 @@
+import Link from "next/link";
+import Reveal from "~/components/reveal/reveal";
+import { getDict } from "~/dict";
+import { getCaseStudies } from "~/lib/case-studies";
+import { PropsWithParams, Lang } from "~/types";
+
+export default async function CaseStudiesPage({ params }: PropsWithParams) {
+  const lang = params.lang as Lang;
+  const { ui } = await getDict(lang);
+  const items = await getCaseStudies(lang);
+  return (
+    <section className="relative mx-auto max-w-5xl px-5 pt-36 pb-24">
+      <Reveal><span className="section-eyebrow">{ui.caseStudiesTitle}</span></Reveal>
+      <div className="mt-8 grid gap-5 sm:grid-cols-2">
+        {items.map((p, i) => (
+          <Reveal key={p.slug} delay={i * 80}>
+            <Link href={`/${lang}/case-studies/${p.slug}`} className="card-surface block rounded-2xl p-6">
+              <span className="text-xs font-bold uppercase tracking-widest text-accent-cyan">{p.caseStudy!.category}</span>
+              <h2 className="mt-2 font-display text-2xl font-bold">{p.title}</h2>
+              <p className="mt-2 text-sm text-muted">{p.description}</p>
+              <span className="mt-4 inline-block text-sm text-accent-fuchsia">{ui.caseStudy} →</span>
+            </Link>
+          </Reveal>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/case-study/case-study-view.tsx
+++ b/src/components/case-study/case-study-view.tsx
@@ -1,0 +1,56 @@
+import Link from "next/link";
+import Reveal from "~/components/reveal/reveal";
+import { getDict } from "~/dict";
+import { Lang } from "~/types";
+import { getCaseStudyBySlug } from "~/lib/case-studies";
+
+type Props = {
+  lang: Lang;
+  project: NonNullable<Awaited<ReturnType<typeof getCaseStudyBySlug>>>;
+};
+
+export default async function CaseStudyView({ lang, project }: Props) {
+  const { ui } = await getDict(lang);
+  const cs = project.caseStudy!;
+  return (
+    <article className="relative mx-auto max-w-3xl px-5 pt-36 pb-24">
+      <Reveal>
+        <Link href={`/${lang}/case-studies`} className="section-eyebrow">← {ui.caseStudiesTitle}</Link>
+      </Reveal>
+      <Reveal delay={80}>
+        <span className="mt-6 block text-xs font-bold uppercase tracking-widest text-accent-cyan">{cs.category}</span>
+        <h1 className="mt-2 font-display text-4xl font-bold tracking-tight">{project.title}</h1>
+        <p className="mt-3 text-muted">{project.description}</p>
+      </Reveal>
+      <Reveal delay={160}>
+        <div className="mt-6 flex flex-wrap gap-2">
+          {project.tags.map((t) => (<span key={t} className="tech-badge">{t}</span>))}
+        </div>
+      </Reveal>
+      <CsBlock delay={220} title={ui.csProblem} body={cs.problem} />
+      <CsBlock delay={260} title={ui.csRole} body={cs.role} />
+      <CsBlock delay={300} title={ui.csSolution} body={cs.solution} />
+      <Reveal delay={340}>
+        <h2 className="mt-10 section-eyebrow">{ui.csResults}</h2>
+        <div className="mt-3 grid gap-4 sm:grid-cols-3">
+          {cs.results.map((r) => (
+            <div key={r.label} className="card-surface rounded-2xl p-5">
+              <div className="gradient-text text-3xl font-bold">{r.value}</div>
+              <div className="mt-1 text-sm text-muted">{r.label}</div>
+            </div>
+          ))}
+        </div>
+      </Reveal>
+      <CsBlock delay={400} title={ui.csLessons} body={cs.lessons} />
+    </article>
+  );
+}
+
+function CsBlock({ title, body, delay }: { title: string; body: string; delay: number }) {
+  return (
+    <Reveal delay={delay}>
+      <h2 className="mt-10 section-eyebrow">{title}</h2>
+      <p className="mt-3 leading-relaxed text-[#d3d5e3]">{body}</p>
+    </Reveal>
+  );
+}

--- a/src/components/footer/footer.tsx
+++ b/src/components/footer/footer.tsx
@@ -30,6 +30,18 @@ export default function Footer() {
 				</div>
 
 				<p className="text-xs text-soft">
+					Telegram kanal:{" "}
+					<Link
+						href="https://t.me/madrimov"
+						target="_blank"
+						rel="noopener"
+						className="text-muted hover:text-white transition-colors"
+					>
+						@madrimov
+					</Link>
+				</p>
+
+				<p className="text-xs text-soft">
 					© {new Date().getFullYear()} Madrimov Xudoshukur
 				</p>
 			</div>

--- a/src/components/footer/footer.tsx
+++ b/src/components/footer/footer.tsx
@@ -30,7 +30,7 @@ export default function Footer() {
 				</div>
 
 				<p className="text-xs text-soft">
-					Telegram kanal:{" "}
+					Telegram:{" "}
 					<Link
 						href="https://t.me/madrimov"
 						target="_blank"

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -101,6 +101,18 @@ export default async function Header({ lang }: PropsWithLang) {
 								</Link>
 							</div>
 						</Reveal>
+						{header.stats && (
+							<Reveal delay={480}>
+								<div className="mt-8 flex flex-wrap gap-x-8 gap-y-3">
+									{header.stats.map((s) => (
+										<div key={s.label}>
+											<div className="gradient-text text-2xl font-bold">{s.value}</div>
+											<div className="text-xs text-muted">{s.label}</div>
+										</div>
+									))}
+								</div>
+							</Reveal>
+						)}
 					</div>
 
 					{/* Avatar */}

--- a/src/components/portfolio/portfolio-card.tsx
+++ b/src/components/portfolio/portfolio-card.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { Dict } from "~/dict";
+import { Lang } from "~/types";
 
 const GRADIENTS: Record<string, string> = {
 	aurora: "from-[#22d3ee] via-[#6366f1] to-[#8b5cf6]",
@@ -14,9 +15,11 @@ const GRADIENTS: Record<string, string> = {
 export default function PortfolioCard({
 	project,
 	ui,
+	lang,
 }: {
 	project: Dict["Index"]["portfolio"]["projects"][number];
 	ui: Dict["Index"]["ui"];
+	lang: Lang;
 }) {
 	const grad = GRADIENTS[project.gradient] ?? GRADIENTS.aurora;
 	const initials = project.title
@@ -78,6 +81,15 @@ export default function PortfolioCard({
 						<span aria-hidden>↗</span>
 					</Link>
 				) : null}
+
+				{project.caseStudy && (
+					<Link
+						href={`/${lang}/case-studies/${project.slug}`}
+						className="mt-3 inline-block text-sm font-medium text-accent-fuchsia"
+					>
+						{ui.caseStudy} →
+					</Link>
+				)}
 			</div>
 		</div>
 	);

--- a/src/components/portfolio/portfolio.tsx
+++ b/src/components/portfolio/portfolio.tsx
@@ -31,7 +31,7 @@ export default async function Portfolio({
 				<div className="mt-10 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
 					{projects.map((project, i) => (
 						<Reveal key={project.title} delay={(i % 3) * 90}>
-							<PortfolioCard project={project} ui={ui} />
+							<PortfolioCard project={project} ui={ui} lang={lang} />
 						</Reveal>
 					))}
 				</div>

--- a/src/dict/en.json
+++ b/src/dict/en.json
@@ -5,6 +5,7 @@
       { "href": "/#about", "title": "About" },
       { "href": "/#skills", "title": "Skills" },
       { "href": "/#experience", "title": "Experience" },
+      { "href": "/case-studies", "title": "Case Studies" },
       { "href": "/portfolio", "title": "Projects" }
     ],
     "header": {

--- a/src/dict/en.json
+++ b/src/dict/en.json
@@ -15,7 +15,12 @@
       "location": "Khiva, Uzbekistan",
       "ctaContact": "Get in touch",
       "ctaCv": "Download CV",
-      "ctaProjects": "Projects"
+      "ctaProjects": "Projects",
+      "stats": [
+        { "value": "4+", "label": "years experience" },
+        { "value": "6", "label": "production systems" },
+        { "value": "3", "label": "OSS npm packages" }
+      ]
     },
     "work": {
       "title": "About me",
@@ -89,20 +94,46 @@
       "projects": [
         {
           "title": "MNazorat",
+          "slug": "mnazorat",
           "description": "A platform for monitoring and controlling organizations' business processes, with a mobile app and a face-recognition module.",
           "tags": ["NestJS", "Prisma", "PostgreSQL", "Redis", "Docker"],
+          "caseStudy": {
+            "category": "GOV / MONITORING",
+            "problem": "Organizations had no single system to monitor and control business processes in real time.",
+            "role": "Backend architecture and system design; integration of the mobile app and face-recognition module.",
+            "solution": "A monitoring platform built on NestJS + Prisma + PostgreSQL, with Redis for caching/queues and Docker deployment. A mobile app and face-recognition module were added.",
+            "results": [
+              { "value": "Real-time", "label": "process monitoring" },
+              { "value": "Mobile", "label": "app + face recognition" }
+            ],
+            "lessons": "Breaking a complex domain into clear modules with well-defined interfaces between services keeps the system maintainable."
+          },
           "gradient": "aurora",
           "private": true
         },
         {
           "title": "M-Smart School",
+          "slug": "m-smart-school",
           "description": "A school management platform: students, attendance, payments and reports. Monorepo with shared types.",
           "tags": ["Bun", "Hono", "React", "Drizzle ORM", "JWT"],
+          "caseStudy": {
+            "category": "GOV / EDTECH",
+            "problem": "Schools tracked attendance, payments and reports manually — time was wasted, errors were common, and there was no transparency for parents.",
+            "role": "Team lead and lead developer: architecture, monorepo, backend and self-hosted infrastructure.",
+            "solution": "A type-safe API (Bun + Hono), monorepo, JWT authentication and a modular system. Attendance, payments and reports on one platform. Self-hosted infrastructure and integration with GPU services (face recognition).",
+            "results": [
+              { "value": "336+", "label": "students (Guliston School #10 pilot)" },
+              { "value": "Live", "label": "running in production" },
+              { "value": "0", "label": "manual reports" }
+            ],
+            "lessons": "I learned that working with real users, managing infrastructure and coordinating a team matters more than the technology itself."
+          },
           "gradient": "ocean",
           "link": "https://msmartschool.uz"
         },
         {
           "title": "M-Smart Kids",
+          "slug": "m-smart-kids",
           "description": "A system for kindergartens: face recognition (FaceID) for attendance and an online payment module.",
           "tags": ["React", "FaceID", "Node.js", "Payments"],
           "gradient": "candy",
@@ -110,20 +141,45 @@
         },
         {
           "title": "e-Jarima maydon",
+          "slug": "e-jarima-maydon",
           "description": "A parking violation system: license-plate recognition from cameras (RTSP / FFmpeg), thermal receipt printing, Electron desktop app.",
           "tags": ["Electron", "RTSP / FFmpeg", "ANPR", "Thermal printer"],
+          "caseStudy": {
+            "category": "GOV / FINTECH",
+            "problem": "Recording parking violations manually was slow and error-prone.",
+            "role": "Lead developer for the desktop app and camera/printer integration.",
+            "solution": "License-plate recognition from cameras (ANPR, RTSP/FFmpeg), thermal receipt printing, and an Electron desktop client. The fine-issuing process was automated.",
+            "results": [
+              { "value": "ANPR", "label": "automatic plate recognition from camera" },
+              { "value": "Thermal", "label": "on-site receipt printing" }
+            ],
+            "lessons": "When working with hardware (cameras, printers), reliability and error handling turned out to be the biggest part of the software."
+          },
           "gradient": "ember",
           "private": true
         },
         {
           "title": "Monro Delivery",
+          "slug": "monro-delivery",
           "description": "Cafe digitization: backend, admin panel and a mobile API for customer and courier, with job queues.",
           "tags": ["Bun", "Hono", "Drizzle ORM", "BullMQ", "Mobile API"],
+          "caseStudy": {
+            "category": "PRODUCT / HORECA",
+            "problem": "The ordering, admin and delivery processes of the \"Monro\" cafe were not digitized.",
+            "role": "Fullstack: backend, admin panel and mobile API.",
+            "solution": "A Bun + Hono + Drizzle ORM backend, a queue system with BullMQ, an admin panel and a mobile API. Managed via Linear.",
+            "results": [
+              { "value": "3-in-1", "label": "backend + admin + mobile API" },
+              { "value": "Active", "label": "in active development" }
+            ],
+            "lessons": "Even for a small business, the right queue architecture is essential for reliable operation."
+          },
           "gradient": "sunset",
           "private": true
         },
         {
           "title": "Online Education",
+          "slug": "online-education",
           "description": "The frontend of an online education platform (LMS): courses, video lessons, PDF certificates and dashboards. Built entirely solo.",
           "tags": ["React", "TypeScript", "Redux Toolkit", "Chakra UI"],
           "gradient": "forest",
@@ -131,6 +187,7 @@
         },
         {
           "title": "Electron Toolkit",
+          "slug": "electron-toolkit",
           "description": "A set of 3 open-source npm packages for Electron apps: POS thermal printer, type-safe storage and window-state management.",
           "tags": ["Electron", "TypeScript", "npm", "Open Source"],
           "gradient": "steel",
@@ -140,7 +197,14 @@
     },
     "ui": {
       "private": "Private",
-      "visit": "Open"
+      "visit": "Open",
+      "caseStudy": "Read case study",
+      "csProblem": "Problem",
+      "csRole": "My role",
+      "csSolution": "Solution & architecture",
+      "csResults": "Results",
+      "csLessons": "What I learned",
+      "caseStudiesTitle": "Case Studies"
     }
   }
 }

--- a/src/dict/index.ts
+++ b/src/dict/index.ts
@@ -9,6 +9,7 @@ type IndexHeader = {
 	ctaContact: string;
 	ctaCv: string;
 	ctaProjects: string;
+	stats?: { value: string; label: string }[];
 };
 
 type Work = {
@@ -48,6 +49,15 @@ type Experience = {
 	organizations: ExperienceItem[];
 };
 
+type CaseStudy = {
+	category: string;
+	problem: string;
+	role: string;
+	solution: string;
+	results: { value: string; label: string }[];
+	lessons: string;
+};
+
 type Project = {
 	title: string;
 	description: string;
@@ -56,6 +66,8 @@ type Project = {
 	link?: string;
 	private?: boolean;
 	img?: string;
+	slug: string;
+	caseStudy?: CaseStudy;
 };
 
 type Portfolio = {
@@ -69,6 +81,13 @@ type Portfolio = {
 type Ui = {
 	private: string;
 	visit: string;
+	caseStudy: string;
+	csProblem: string;
+	csRole: string;
+	csSolution: string;
+	csResults: string;
+	csLessons: string;
+	caseStudiesTitle: string;
 };
 
 type Index = {

--- a/src/dict/ru.json
+++ b/src/dict/ru.json
@@ -15,7 +15,12 @@
       "location": "Хива, Узбекистан",
       "ctaContact": "Связаться",
       "ctaCv": "Скачать CV",
-      "ctaProjects": "Проекты"
+      "ctaProjects": "Проекты",
+      "stats": [
+        { "value": "4+", "label": "лет опыта" },
+        { "value": "6", "label": "production-систем" },
+        { "value": "3", "label": "OSS npm-пакета" }
+      ]
     },
     "work": {
       "title": "Обо мне",
@@ -89,20 +94,46 @@
       "projects": [
         {
           "title": "MNazorat",
+          "slug": "mnazorat",
           "description": "Платформа мониторинга и контроля бизнес-процессов организаций с мобильным приложением и модулем распознавания лиц.",
           "tags": ["NestJS", "Prisma", "PostgreSQL", "Redis", "Docker"],
+          "caseStudy": {
+            "category": "GOV / MONITORING",
+            "problem": "В организациях не было единой системы для мониторинга и контроля бизнес-процессов в реальном времени.",
+            "role": "Backend-архитектура и проектирование системы; интеграция мобильного приложения и модуля распознавания лиц.",
+            "solution": "Платформа мониторинга на NestJS + Prisma + PostgreSQL, кэш/очереди на Redis, деплой в Docker. Добавлены мобильное приложение и модуль распознавания лиц.",
+            "results": [
+              { "value": "Real-time", "label": "мониторинг процессов" },
+              { "value": "Мобильное", "label": "приложение + распознавание лиц" }
+            ],
+            "lessons": "Разбиение сложного домена на чёткие модули и ясные интерфейсы между сервисами делает систему управляемой."
+          },
           "gradient": "aurora",
           "private": true
         },
         {
           "title": "M-Smart School",
+          "slug": "m-smart-school",
           "description": "Платформа управления школой: ученики, посещаемость, оплаты и отчёты. Монорепозиторий с общими типами.",
           "tags": ["Bun", "Hono", "React", "Drizzle ORM", "JWT"],
+          "caseStudy": {
+            "category": "GOV / EDTECH",
+            "problem": "В школах посещаемость, оплаты и отчёты вели вручную — терялось время, было много ошибок, а для родителей не было прозрачности.",
+            "role": "Тимлид и ведущий разработчик: архитектура, монорепо, бэкенд и self-hosted инфраструктура.",
+            "solution": "Type-safe API (Bun + Hono), монорепо, JWT-аутентификация и модульная система. Посещаемость, оплаты и отчёты на одной платформе. Self-hosted инфраструктура и интеграция с GPU-сервисами (распознавание лиц).",
+            "results": [
+              { "value": "336+", "label": "учеников (пилот, 10-я школа Гулистана)" },
+              { "value": "Live", "label": "работает в production" },
+              { "value": "0", "label": "ручных отчётов" }
+            ],
+            "lessons": "Я понял, что работа с реальными пользователями, управление инфраструктурой и координация команды важнее самих технологий."
+          },
           "gradient": "ocean",
           "link": "https://msmartschool.uz"
         },
         {
           "title": "M-Smart Kids",
+          "slug": "m-smart-kids",
           "description": "Система для детских садов: распознавание лиц (FaceID) для отметки посещаемости и модуль онлайн-оплаты.",
           "tags": ["React", "FaceID", "Node.js", "Платежи"],
           "gradient": "candy",
@@ -110,20 +141,45 @@
         },
         {
           "title": "e-Jarima maydon",
+          "slug": "e-jarima-maydon",
           "description": "Система фиксации правонарушений на парковке: распознавание автономеров с камер (RTSP / FFmpeg), печать чеков на термопринтере, десктоп на Electron.",
           "tags": ["Electron", "RTSP / FFmpeg", "ANPR", "Термопринтер"],
+          "caseStudy": {
+            "category": "GOV / FINTECH",
+            "problem": "Ручная фиксация нарушений на парковке была медленной и подверженной ошибкам.",
+            "role": "Ведущий разработчик десктоп-приложения и интеграции камер/принтера.",
+            "solution": "Распознавание автономеров с камер (ANPR, RTSP/FFmpeg), печать чеков на термопринтере, десктоп-клиент на Electron. Процесс выписки штрафов автоматизирован.",
+            "results": [
+              { "value": "ANPR", "label": "автоматическое распознавание номеров с камеры" },
+              { "value": "Термо", "label": "печать чека на месте" }
+            ],
+            "lessons": "При работе с оборудованием (камеры, принтеры) надёжность и обработка ошибок оказались самой большой частью программы."
+          },
           "gradient": "ember",
           "private": true
         },
         {
           "title": "Monro Delivery",
+          "slug": "monro-delivery",
           "description": "Цифровизация кафе: backend, админ-панель и мобильный API для клиента и курьера с очередями задач.",
           "tags": ["Bun", "Hono", "Drizzle ORM", "BullMQ", "Mobile API"],
+          "caseStudy": {
+            "category": "PRODUCT / HORECA",
+            "problem": "Процессы заказов, администрирования и доставки кафе «Monro» не были оцифрованы.",
+            "role": "Fullstack: бэкенд, админ-панель и мобильный API.",
+            "solution": "Бэкенд на Bun + Hono + Drizzle ORM, система очередей на BullMQ, админ-панель и мобильный API. Управление через Linear.",
+            "results": [
+              { "value": "3-in-1", "label": "бэкенд + админка + мобильный API" },
+              { "value": "Active", "label": "в активной разработке" }
+            ],
+            "lessons": "Даже для малого бизнеса правильная архитектура очередей необходима для надёжной работы."
+          },
           "gradient": "sunset",
           "private": true
         },
         {
           "title": "Online Education",
+          "slug": "online-education",
           "description": "Фронтенд платформы онлайн-образования (LMS): курсы, видео-уроки, сертификаты в PDF и дашборды. Разработан полностью в одиночку.",
           "tags": ["React", "TypeScript", "Redux Toolkit", "Chakra UI"],
           "gradient": "forest",
@@ -131,6 +187,7 @@
         },
         {
           "title": "Electron Toolkit",
+          "slug": "electron-toolkit",
           "description": "Набор из 3 open-source npm-пакетов для Electron-приложений: термопринтер POS, типобезопасное хранилище и управление состоянием окна.",
           "tags": ["Electron", "TypeScript", "npm", "Open Source"],
           "gradient": "steel",
@@ -140,7 +197,14 @@
     },
     "ui": {
       "private": "Приватный",
-      "visit": "Открыть"
+      "visit": "Открыть",
+      "caseStudy": "Подробнее",
+      "csProblem": "Проблема",
+      "csRole": "Моя роль",
+      "csSolution": "Решение и архитектура",
+      "csResults": "Результат",
+      "csLessons": "Чему я научился",
+      "caseStudiesTitle": "Кейсы"
     }
   }
 }

--- a/src/dict/ru.json
+++ b/src/dict/ru.json
@@ -5,6 +5,7 @@
       { "href": "/#about", "title": "Обо мне" },
       { "href": "/#skills", "title": "Навыки" },
       { "href": "/#experience", "title": "Опыт" },
+      { "href": "/case-studies", "title": "Кейсы" },
       { "href": "/portfolio", "title": "Проекты" }
     ],
     "header": {

--- a/src/dict/uz.json
+++ b/src/dict/uz.json
@@ -15,7 +15,12 @@
       "location": "Xiva, O'zbekiston",
       "ctaContact": "Bog'lanish",
       "ctaCv": "CV yuklab olish",
-      "ctaProjects": "Loyihalar"
+      "ctaProjects": "Loyihalar",
+      "stats": [
+        { "value": "4+", "label": "yil tajriba" },
+        { "value": "6", "label": "production tizim" },
+        { "value": "3", "label": "OSS npm paket" }
+      ]
     },
     "work": {
       "title": "Men haqimda",
@@ -89,20 +94,46 @@
       "projects": [
         {
           "title": "MNazorat",
+          "slug": "mnazorat",
           "description": "Tashkilotlarning biznes-jarayonlarini monitoring va nazorat qilish platformasi; mobil ilova va yuzni aniqlash moduli bilan.",
           "tags": ["NestJS", "Prisma", "PostgreSQL", "Redis", "Docker"],
+          "caseStudy": {
+            "category": "GOV / MONITORING",
+            "problem": "Tashkilotlarda biznes-jarayonlarni real vaqtda kuzatish va nazorat qilish uchun yagona tizim yo'q edi.",
+            "role": "Backend arxitektura va tizim dizayni; mobil app va yuz tanish modulini integratsiya.",
+            "solution": "NestJS + Prisma + PostgreSQL asosida monitoring platformasi, Redis bilan kesh/navbat, Docker'da deploy. Mobil ilova va yuz tanish moduli qo'shildi.",
+            "results": [
+              { "value": "Real-time", "label": "jarayon monitoringi" },
+              { "value": "Mobil", "label": "ilova + yuz tanish" }
+            ],
+            "lessons": "Murakkab domenni aniq modullarga ajratish va xizmatlararo aniq interfeyslar tizimni boshqariladigan qiladi."
+          },
           "gradient": "aurora",
           "private": true
         },
         {
           "title": "M-Smart School",
+          "slug": "m-smart-school",
           "description": "Maktab boshqaruvi platformasi: o'quvchilar, davomat, to'lovlar va hisobotlar. Umumiy tiplar bilan monorepozitoriy.",
           "tags": ["Bun", "Hono", "React", "Drizzle ORM", "JWT"],
+          "caseStudy": {
+            "category": "GOV / EDTECH",
+            "problem": "Maktablarda davomat, to'lov va hisobotlar qo'lda yuritilardi — vaqt yo'qoladi, xatolar ko'p, ota-onalar uchun shaffoflik yo'q edi.",
+            "role": "Tim lead va asosiy dasturchi: arxitektura, monorepo, backend va self-hosted infratuzilma.",
+            "solution": "Type-safe API (Bun + Hono), monorepo, JWT autentifikatsiya va modulli tizim. Davomat, to'lov, hisobotlar bitta platformada. Self-hosted infra va GPU xizmatlar (yuz tanish) bilan integratsiya.",
+            "results": [
+              { "value": "336+", "label": "o'quvchi (Guliston 10-maktab pilot)" },
+              { "value": "Live", "label": "production'da ishlamoqda" },
+              { "value": "0", "label": "qo'lda hisobot" }
+            ],
+            "lessons": "Real foydalanuvchilar bilan ishlash, infra boshqaruvi va jamoani muvofiqlashtirish — texnologiyadan ko'ra muhimroq ekanini o'rgandim."
+          },
           "gradient": "ocean",
           "link": "https://msmartschool.uz"
         },
         {
           "title": "M-Smart Kids",
+          "slug": "m-smart-kids",
           "description": "Bog'chalar uchun tizim: davomatni belgilash uchun yuzni aniqlash (FaceID) va onlayn to'lov moduli.",
           "tags": ["React", "FaceID", "Node.js", "To'lovlar"],
           "gradient": "candy",
@@ -110,20 +141,45 @@
         },
         {
           "title": "e-Jarima maydon",
+          "slug": "e-jarima-maydon",
           "description": "Parkovkadagi qoidabuzarliklarni qayd etish tizimi: kameralardan avto-raqamni aniqlash (RTSP / FFmpeg), termoprinterda chek chop etish, Electron desktop.",
           "tags": ["Electron", "RTSP / FFmpeg", "ANPR", "Termoprinter"],
+          "caseStudy": {
+            "category": "GOV / FINTECH",
+            "problem": "Parkovkadagi qoidabuzarliklarni qo'lda qayd etish sekin va xatoga moyil edi.",
+            "role": "Desktop ilova va kamera/printer integratsiyasi bo'yicha asosiy dasturchi.",
+            "solution": "Kameralardan avtomobil raqamini tanish (ANPR, RTSP/FFmpeg), termoprinterda chek chop etish, Electron'da desktop mijoz. Jarima jarayoni avtomatlashtirildi.",
+            "results": [
+              { "value": "ANPR", "label": "kameradan avtomatik raqam tanish" },
+              { "value": "Termo", "label": "joyida chek chop etish" }
+            ],
+            "lessons": "Apparat (kamera, printer) bilan ishlashda ishonchlilik va xatolarni bartaraf etish dasturning eng katta qismi ekan."
+          },
           "gradient": "ember",
           "private": true
         },
         {
           "title": "Monro Delivery",
+          "slug": "monro-delivery",
           "description": "Kafeni raqamlashtirish: backend, admin-panel va mijoz hamda kuryer uchun mobil API, navbatlar bilan.",
           "tags": ["Bun", "Hono", "Drizzle ORM", "BullMQ", "Mobile API"],
+          "caseStudy": {
+            "category": "PRODUCT / HORECA",
+            "problem": "«Monro» kafesining buyurtma, admin va yetkazib berish jarayonlari raqamlashtirilmagan edi.",
+            "role": "Fullstack: backend, admin panel va mobil API.",
+            "solution": "Bun + Hono + Drizzle ORM backend, BullMQ bilan navbat tizimi, admin panel va mobil API. Linear orqali boshqariladi.",
+            "results": [
+              { "value": "3-in-1", "label": "backend + admin + mobil API" },
+              { "value": "Active", "label": "ishlab chiqilmoqda" }
+            ],
+            "lessons": "Kichik biznes uchun ham to'g'ri navbat/queue arxitekturasi ishonchli ish faoliyati uchun zarur."
+          },
           "gradient": "sunset",
           "private": true
         },
         {
           "title": "Online Education",
+          "slug": "online-education",
           "description": "Onlayn ta'lim platformasi (LMS) frontendi: kurslar, video-darslar, PDF sertifikatlar va dashboardlar. To'liq yakka ishlab chiqilgan.",
           "tags": ["React", "TypeScript", "Redux Toolkit", "Chakra UI"],
           "gradient": "forest",
@@ -131,6 +187,7 @@
         },
         {
           "title": "Electron Toolkit",
+          "slug": "electron-toolkit",
           "description": "Electron ilovalari uchun 3 ta open-source npm paket: POS termoprinter, tip-xavfsiz xotira va oyna holatini boshqarish.",
           "tags": ["Electron", "TypeScript", "npm", "Open Source"],
           "gradient": "steel",
@@ -140,7 +197,14 @@
     },
     "ui": {
       "private": "Maxfiy",
-      "visit": "Ochish"
+      "visit": "Ochish",
+      "caseStudy": "Batafsil",
+      "csProblem": "Muammo",
+      "csRole": "Mening rolim",
+      "csSolution": "Yechim va arxitektura",
+      "csResults": "Natija",
+      "csLessons": "Nimani o'rgandim",
+      "caseStudiesTitle": "Case Studies"
     }
   }
 }

--- a/src/dict/uz.json
+++ b/src/dict/uz.json
@@ -5,6 +5,7 @@
       { "href": "/#about", "title": "Men haqimda" },
       { "href": "/#skills", "title": "Ko'nikmalar" },
       { "href": "/#experience", "title": "Tajriba" },
+      { "href": "/case-studies", "title": "Case Studies" },
       { "href": "/portfolio", "title": "Loyihalar" }
     ],
     "header": {

--- a/src/lib/case-studies.ts
+++ b/src/lib/case-studies.ts
@@ -1,0 +1,17 @@
+import { getDict } from "~/dict";
+import { Lang } from "~/types";
+
+export async function getCaseStudies(lang: Lang) {
+  const dict = await getDict(lang);
+  return dict.portfolio.projects.filter((p) => p.caseStudy);
+}
+
+export async function getCaseStudyBySlug(lang: Lang, slug: string) {
+  const dict = await getDict(lang);
+  return dict.portfolio.projects.find((p) => p.slug === slug && p.caseStudy) ?? null;
+}
+
+export async function getAllCaseStudySlugs(lang: Lang) {
+  const items = await getCaseStudies(lang);
+  return items.map((p) => p.slug);
+}


### PR DESCRIPTION
## Xulosa

Mavjud dark/gradient dizaynni **o'zgartirmasdan** brand qatlamini qo'shadi (Authority Hub strategiyasining 1-fazasi):

- **Case Study tizimi** — 4 ta yirik loyiha (M-Smart School, MNazorat, e-Jarima maydon, Monro Delivery) uchun chuqur sahifa: *Muammo → Mening rolim → Yechim/Arxitektura → Natija (raqamlar) → Saboq*
- **Yangi route'lar:** `/[lang]/case-studies` (ro'yxat) va `/[lang]/case-studies/[slug]` (SSG, `dynamicParams=false`, 404 himoyasi)
- **Hero raqamlari:** 4+ yil · 6 production tizim · 3 OSS npm paket
- **Portfolio kartochkalari** caseStudy bor loyihalarga "Batafsil" linki
- **Navigatsiya** — "Case Studies" menyu bandi + footer'da Telegram CTA
- **i18n:** uz/ru/en to'liq sinxron (slug'lar va raqamlar bir xil, faqat matn tarjima)

Tip darajasida: `CaseStudy` tipi, `Project.slug`/`caseStudy?`, `IndexHeader.stats?`, 7 ta yangi `Ui` yorlig'i. Mavjud pattern'lar (dict-driven i18n, `Reveal`, `~/` alias, `card-surface`/`tech-badge`/`section-eyebrow` CSS) qayta ishlatildi.

## Test Plan

- [x] `tsc --noEmit` — xatosiz
- [x] `next build` — muvaffaqiyatli (17 sahifa, 12 case study prerendered)
- [x] `next lint` — toza (faqat pre-existing warning)
- [x] 3 tilda case study sahifalari render bo'ladi (uz/ru/en → 200)
- [x] Noto'g'ri slug → 404
- [ ] Vizual ko'rinish dark temaga mos (qo'lda tekshirish)
- [ ] Mobil/desktop responsive (qo'lda tekshirish)

## Faza 2 (keyingi)

Vizual reskin (dark/gradient → oq/qizil Bold Editorial) — alohida PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)