### PR TITLE
feat: vizual reskin — Bold Editorial (Faza 2)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -8,140 +8,136 @@
 		-webkit-text-size-adjust: 100%;
 	}
 	body {
-		background-color: #0a0a0f;
-		color: #e7e8f0;
+		background-color: #f7f5f0;
+		color: #0a0a0a;
 		overflow-x: hidden;
 	}
 	::selection {
-		background: rgba(139, 92, 246, 0.35);
+		background: #e11d48;
 		color: #fff;
 	}
 	::-webkit-scrollbar {
 		width: 10px;
 	}
 	::-webkit-scrollbar-track {
-		background: #0a0a0f;
+		background: #f7f5f0;
 	}
 	::-webkit-scrollbar-thumb {
-		background: #2a2a3a;
+		background: #d8d3c8;
 		border-radius: 999px;
 	}
 	::-webkit-scrollbar-thumb:hover {
-		background: #3a3a50;
+		background: #e11d48;
 	}
 }
 
 @layer components {
-	/* Gradient text */
+	/* Headline accent — was a gradient, now solid ink (Bold Editorial).
+	   Pair with .text-accent for the red highlight word. */
 	.gradient-text {
-		background-image: linear-gradient(
-			110deg,
-			#22d3ee 0%,
-			#8b5cf6 45%,
-			#e879f9 100%
-		);
-		background-size: 200% auto;
-		-webkit-background-clip: text;
-		background-clip: text;
-		color: transparent;
-		animation: gradient-shift 6s ease infinite;
+		color: #0a0a0a;
 	}
 
-	/* Glass card */
+	/* Glass card → frosted paper */
 	.glass {
-		background: rgba(22, 22, 31, 0.6);
+		background: rgba(255, 255, 255, 0.72);
 		backdrop-filter: blur(12px);
 		-webkit-backdrop-filter: blur(12px);
-		border: 1px solid rgba(255, 255, 255, 0.07);
+		border: 1px solid #e4e0d8;
 	}
 
 	.card-surface {
-		background: linear-gradient(
-			180deg,
-			rgba(28, 28, 40, 0.7),
-			rgba(18, 18, 26, 0.7)
-		);
-		border: 1px solid rgba(255, 255, 255, 0.07);
+		background: #ffffff;
+		border: 1px solid #e4e0d8;
 		transition: transform 0.35s cubic-bezier(0.22, 1, 0.36, 1),
 			border-color 0.35s ease, box-shadow 0.35s ease;
 	}
 	.card-surface:hover {
 		transform: translateY(-6px);
-		border-color: rgba(139, 92, 246, 0.45);
-		box-shadow: 0 18px 50px -20px rgba(139, 92, 246, 0.45);
+		border-color: #e11d48;
+		box-shadow: 0 18px 44px -22px rgba(225, 29, 72, 0.45);
 	}
 
-	/* Grid / dotted background */
+	/* Dotted grid background (subtle ink dots on paper) */
 	.bg-grid {
 		background-image: radial-gradient(
-			rgba(255, 255, 255, 0.05) 1px,
+			rgba(10, 10, 10, 0.07) 1px,
 			transparent 1px
 		);
 		background-size: 26px 26px;
 	}
 
-	/* Pill / badge */
+	/* Pill / badge — monospace, ink on paper, red border */
 	.tech-badge {
 		display: inline-flex;
 		align-items: center;
+		font-family: var(--font-mono), ui-monospace, monospace;
 		font-size: 0.72rem;
-		font-weight: 600;
+		font-weight: 500;
 		letter-spacing: 0.01em;
 		padding: 0.28rem 0.66rem;
 		border-radius: 999px;
-		color: #c9cce0;
-		background: rgba(139, 92, 246, 0.1);
-		border: 1px solid rgba(139, 92, 246, 0.25);
+		color: #44403c;
+		background: #ffffff;
+		border: 1px solid #e4e0d8;
 		white-space: nowrap;
 	}
 
-	/* Buttons */
+	/* Primary button — solid ink, paper text (editorial) */
 	.btn-grad {
 		display: inline-flex;
 		align-items: center;
 		gap: 0.5rem;
-		font-weight: 600;
+		font-weight: 700;
 		padding: 0.7rem 1.3rem;
-		border-radius: 0.85rem;
-		color: #0a0a0f;
-		background: linear-gradient(110deg, #22d3ee, #8b5cf6, #e879f9);
-		background-size: 180% auto;
-		transition: background-position 0.5s ease, transform 0.2s ease,
-			box-shadow 0.3s ease;
-		box-shadow: 0 10px 30px -12px rgba(139, 92, 246, 0.7);
+		border-radius: 0.4rem;
+		color: #f7f5f0;
+		background: #0a0a0a;
+		transition: transform 0.2s ease, box-shadow 0.3s ease, background 0.3s ease;
+		box-shadow: 0 10px 26px -14px rgba(10, 10, 10, 0.6);
 	}
 	.btn-grad:hover {
-		background-position: right center;
+		background: #e11d48;
 		transform: translateY(-2px);
+		box-shadow: 0 12px 30px -14px rgba(225, 29, 72, 0.6);
 	}
+
+	/* Secondary button — outline */
 	.btn-ghost-line {
 		display: inline-flex;
 		align-items: center;
 		gap: 0.5rem;
 		font-weight: 600;
 		padding: 0.7rem 1.3rem;
-		border-radius: 0.85rem;
-		color: #e7e8f0;
-		border: 1px solid rgba(255, 255, 255, 0.14);
-		background: rgba(255, 255, 255, 0.02);
+		border-radius: 0.4rem;
+		color: #0a0a0a;
+		border: 1px solid #d8d3c8;
+		background: transparent;
 		transition: border-color 0.3s ease, background 0.3s ease,
 			transform 0.2s ease;
 	}
 	.btn-ghost-line:hover {
-		border-color: rgba(139, 92, 246, 0.6);
-		background: rgba(139, 92, 246, 0.1);
+		border-color: #e11d48;
+		color: #e11d48;
 		transform: translateY(-2px);
 	}
 
+	/* Section label — monospace red eyebrow (terminal bridge) */
 	.section-eyebrow {
 		display: inline-flex;
 		align-items: center;
 		gap: 0.5rem;
+		font-family: var(--font-mono), ui-monospace, monospace;
 		font-size: 0.72rem;
-		font-weight: 700;
-		letter-spacing: 0.18em;
+		font-weight: 600;
+		letter-spacing: 0.14em;
 		text-transform: uppercase;
-		color: #8b5cf6;
+		color: #e11d48;
+	}
+
+	/* Red highlight word inside a headline */
+	.text-accent {
+		color: #e11d48;
 	}
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,17 +1,25 @@
-import { Inter, Space_Grotesk } from "next/font/google";
+import { IBM_Plex_Sans, Bricolage_Grotesque, JetBrains_Mono } from "next/font/google";
 import "./globals.css";
 import { Analytics } from "@vercel/analytics/react";
 
-const inter = Inter({
-	subsets: ["latin", "cyrillic"],
+const plexSans = IBM_Plex_Sans({
+	subsets: ["latin"],
+	weight: ["400", "500", "600", "700"],
 	variable: "--font-sans",
 	display: "swap",
 });
 
-const spaceGrotesk = Space_Grotesk({
+const bricolage = Bricolage_Grotesque({
 	subsets: ["latin"],
-	weight: ["500", "600", "700"],
+	weight: ["600", "700", "800"],
 	variable: "--font-display",
+	display: "swap",
+});
+
+const jetbrainsMono = JetBrains_Mono({
+	subsets: ["latin"],
+	weight: ["400", "500", "700"],
+	variable: "--font-mono",
 	display: "swap",
 });
 
@@ -26,9 +34,9 @@ export default async function RootLayout({
 	return (
 		<html
 			lang="en"
-			className={`h-full ${inter.variable} ${spaceGrotesk.variable}`}
+			className={`h-full ${plexSans.variable} ${bricolage.variable} ${jetbrainsMono.variable}`}
 		>
-			<body className="font-sans h-full flex flex-col bg-ink text-[#e7e8f0] antialiased">
+			<body className="font-sans h-full flex flex-col bg-paper text-ink antialiased">
 				{children}
 				<Analytics />
 			</body>

--- a/src/components/case-study/case-study-view.tsx
+++ b/src/components/case-study/case-study-view.tsx
@@ -50,7 +50,7 @@ function CsBlock({ title, body, delay }: { title: string; body: string; delay: n
   return (
     <Reveal delay={delay}>
       <h2 className="mt-10 section-eyebrow">{title}</h2>
-      <p className="mt-3 leading-relaxed text-[#d3d5e3]">{body}</p>
+      <p className="mt-3 leading-relaxed text-[#1c1917]">{body}</p>
     </Reveal>
   );
 }

--- a/src/components/experience/experience.tsx
+++ b/src/components/experience/experience.tsx
@@ -24,11 +24,11 @@ export default async function Experience({ lang }: PropsWithLang) {
 							<Reveal key={org.organization} delay={i * 100}>
 								<div className="relative pl-8 sm:pl-12">
 									{/* dot */}
-									<span className="absolute left-0 top-2 h-[15px] w-[15px] rounded-full bg-ink border-2 border-accent shadow-[0_0_0_4px_rgba(139,92,246,0.15)] sm:left-[2px]" />
+									<span className="absolute left-0 top-2 h-[15px] w-[15px] rounded-full bg-ink border-2 border-accent shadow-[0_0_0_4px_rgba(225,29,72,0.14)] sm:left-[2px]" />
 
 									<div className="card-surface rounded-2xl p-6">
 										<div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1">
-											<h3 className="font-display text-xl font-bold text-white">
+											<h3 className="font-display text-xl font-bold text-ink">
 												{org.organization}
 											</h3>
 											<span className="text-xs font-semibold uppercase tracking-wider text-accent-cyan">
@@ -44,7 +44,7 @@ export default async function Experience({ lang }: PropsWithLang) {
 												href={`https://${org.link}`}
 												target="_blank"
 												rel="noopener"
-												className="mt-0.5 inline-block text-xs text-soft hover:text-white transition-colors"
+												className="mt-0.5 inline-block text-xs text-soft hover:text-ink transition-colors"
 											>
 												{org.link} ↗
 											</Link>
@@ -59,7 +59,7 @@ export default async function Experience({ lang }: PropsWithLang) {
 												{org.projects.map((p) => (
 													<span
 														key={p}
-														className="inline-flex items-center gap-1.5 rounded-lg border border-white/10 bg-white/[0.03] px-2.5 py-1 text-xs font-medium text-[#c9cce0]"
+														className="inline-flex items-center gap-1.5 rounded-lg border border-line bg-black/[0.02] px-2.5 py-1 text-xs font-medium text-muted"
 													>
 														<span className="h-1.5 w-1.5 rounded-full bg-accent-fuchsia" />
 														{p}

--- a/src/components/footer/footer.tsx
+++ b/src/components/footer/footer.tsx
@@ -8,11 +8,11 @@ const SOCIALS = [
 
 export default function Footer() {
 	return (
-		<footer className="relative mt-10 border-t border-white/10">
+		<footer className="relative mt-10 border-t border-line">
 			<div className="mx-auto max-w-5xl px-5 py-10 flex flex-col items-center gap-4 sm:flex-row sm:justify-between">
 				<Link href="/" className="font-display text-lg font-bold">
 					<span className="gradient-text">{`</>`}</span>
-					<span className="ml-2 text-white">madrimov.uz</span>
+					<span className="ml-2 text-ink">madrimov.uz</span>
 				</Link>
 
 				<div className="flex items-center gap-5 text-sm">
@@ -22,7 +22,7 @@ export default function Footer() {
 							href={s.href}
 							target={s.href.startsWith("mailto") ? undefined : "_blank"}
 							rel="noopener"
-							className="text-muted hover:text-white transition-colors"
+							className="text-muted hover:text-ink transition-colors"
 						>
 							{s.label}
 						</Link>
@@ -35,7 +35,7 @@ export default function Footer() {
 						href="https://t.me/madrimov"
 						target="_blank"
 						rel="noopener"
-						className="text-muted hover:text-white transition-colors"
+						className="text-muted hover:text-ink transition-colors"
 					>
 						@madrimov
 					</Link>

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -11,11 +11,9 @@ export default async function Header({ lang }: PropsWithLang) {
 			id="top"
 			className="relative overflow-hidden pt-36 pb-20 sm:pt-44 sm:pb-28"
 		>
-			{/* Background */}
-			<div className="pointer-events-none absolute inset-0 bg-grid opacity-60" />
-			<div className="pointer-events-none absolute -top-40 -left-32 h-[28rem] w-[28rem] rounded-full bg-accent-indigo/30 blur-[120px]" />
-			<div className="pointer-events-none absolute -top-24 right-0 h-[26rem] w-[26rem] rounded-full bg-accent-fuchsia/20 blur-[120px]" />
-			<div className="pointer-events-none absolute bottom-0 left-1/3 h-[22rem] w-[22rem] rounded-full bg-accent-cyan/15 blur-[120px]" />
+			{/* Background — paper with subtle ink dots + one soft red wash */}
+			<div className="pointer-events-none absolute inset-0 bg-grid opacity-70" />
+			<div className="pointer-events-none absolute -top-32 right-0 h-[26rem] w-[26rem] rounded-full bg-accent/5 blur-[120px]" />
 
 			<div className="relative mx-auto max-w-5xl px-5">
 				<div className="flex flex-col-reverse items-center gap-10 sm:flex-row sm:items-center sm:justify-between">
@@ -27,12 +25,12 @@ export default async function Header({ lang }: PropsWithLang) {
 							</span>
 						</Reveal>
 						<Reveal delay={80}>
-							<h1 className="mt-4 font-display text-[2rem] sm:text-6xl font-bold tracking-tight leading-[1.08] break-words">
+							<h1 className="mt-4 font-display text-[2.25rem] sm:text-7xl font-extrabold tracking-tight leading-[1.02] break-words text-ink">
 								{header.name}
 							</h1>
 						</Reveal>
 						<Reveal delay={160}>
-							<p className="mt-3 font-display text-lg sm:text-3xl font-semibold gradient-text break-words">
+							<p className="mt-3 font-display text-lg sm:text-3xl font-bold text-accent break-words">
 								{header.jobTitle}
 							</p>
 						</Reveal>

--- a/src/components/my-work/my-work.tsx
+++ b/src/components/my-work/my-work.tsx
@@ -45,7 +45,7 @@ export default async function MyWork({ lang }: PropsWithLang) {
 										href={work.links[key]}
 										target={work.links[key].startsWith("mailto") ? undefined : "_blank"}
 										rel="noopener"
-										className="group inline-flex items-center gap-2 rounded-xl border border-white/10 bg-white/[0.02] px-4 py-2.5 text-sm font-medium text-muted hover:text-white hover:border-accent/50 hover:bg-accent/10 transition-colors"
+										className="group inline-flex items-center gap-2 rounded-xl border border-line bg-black/[0.02] px-4 py-2.5 text-sm font-medium text-muted hover:text-ink hover:border-accent/50 hover:bg-accent/10 transition-colors"
 									>
 										<svg
 											xmlns="http://www.w3.org/2000/svg"

--- a/src/components/navbar/navbar.tsx
+++ b/src/components/navbar/navbar.tsx
@@ -29,7 +29,7 @@ export default function Navbar({ items }: { items: MenuItem[] }) {
 		<div className="fixed top-0 inset-x-0 z-50 flex justify-center px-3 lg:px-0">
 			<nav
 				className={`mt-4 w-full max-w-3xl rounded-2xl glass transition-all duration-300 ${
-					scrolled ? "shadow-[0_10px_40px_-18px_rgba(139,92,246,0.5)]" : ""
+					scrolled ? "shadow-[0_10px_40px_-18px_rgba(225,29,72,0.28)]" : ""
 				}`}
 			>
 				<div className="flex items-center justify-between gap-2 px-3 py-2">
@@ -47,7 +47,7 @@ export default function Navbar({ items }: { items: MenuItem[] }) {
 							<li key={item.href}>
 								<Link
 									href={`/${lang}${item.href}`}
-									className="px-3 py-2 rounded-lg text-muted hover:text-white hover:bg-white/5 transition-colors"
+									className="px-3 py-2 rounded-lg text-muted hover:text-ink hover:bg-black/[0.03] transition-colors"
 								>
 									{item.title}
 								</Link>
@@ -57,15 +57,15 @@ export default function Navbar({ items }: { items: MenuItem[] }) {
 
 					{/* Right: language + mobile toggle */}
 					<div className="flex items-center gap-1">
-						<div className="flex items-center rounded-lg border border-white/10 p-0.5">
+						<div className="flex items-center rounded-lg border border-line p-0.5">
 							{LANGS.map((l) => (
 								<button
 									key={l}
 									onClick={() => router.push(`/${l}${locale ? `/${locale.replace(/^\//, "")}` : ""}`)}
 									className={`px-2 py-1 rounded-md text-xs font-semibold uppercase transition-colors ${
 										lang === l
-											? "bg-accent/90 text-white"
-											: "text-soft hover:text-white"
+											? "bg-accent text-paper"
+											: "text-soft hover:text-ink"
 									}`}
 								>
 									{l}
@@ -76,7 +76,7 @@ export default function Navbar({ items }: { items: MenuItem[] }) {
 						<button
 							aria-label="Menu"
 							onClick={() => setOpen((v) => !v)}
-							className="md:hidden p-2 rounded-lg text-muted hover:text-white hover:bg-white/5"
+							className="md:hidden p-2 rounded-lg text-muted hover:text-ink hover:bg-black/[0.03]"
 						>
 							<svg
 								xmlns="http://www.w3.org/2000/svg"
@@ -98,13 +98,13 @@ export default function Navbar({ items }: { items: MenuItem[] }) {
 
 				{/* Mobile menu */}
 				{open && (
-					<ul className="md:hidden border-t border-white/10 px-2 py-2 flex flex-col">
+					<ul className="md:hidden border-t border-line px-2 py-2 flex flex-col">
 						{items.map((item) => (
 							<li key={item.href}>
 								<Link
 									href={`/${lang}${item.href}`}
 									onClick={() => setOpen(false)}
-									className="block px-3 py-2.5 rounded-lg text-muted hover:text-white hover:bg-white/5 transition-colors"
+									className="block px-3 py-2.5 rounded-lg text-muted hover:text-ink hover:bg-black/[0.03] transition-colors"
 								>
 									{item.title}
 								</Link>

--- a/src/components/portfolio/portfolio-card.tsx
+++ b/src/components/portfolio/portfolio-card.tsx
@@ -2,16 +2,6 @@ import Link from "next/link";
 import { Dict } from "~/dict";
 import { Lang } from "~/types";
 
-const GRADIENTS: Record<string, string> = {
-	aurora: "from-[#22d3ee] via-[#6366f1] to-[#8b5cf6]",
-	ocean: "from-[#0ea5e9] via-[#2563eb] to-[#4f46e5]",
-	candy: "from-[#f472b6] via-[#e879f9] to-[#a855f7]",
-	ember: "from-[#fb7185] via-[#f97316] to-[#f59e0b]",
-	sunset: "from-[#f59e0b] via-[#ec4899] to-[#8b5cf6]",
-	forest: "from-[#34d399] via-[#10b981] to-[#0891b2]",
-	steel: "from-[#94a3b8] via-[#64748b] to-[#475569]",
-};
-
 export default function PortfolioCard({
 	project,
 	ui,
@@ -21,7 +11,6 @@ export default function PortfolioCard({
 	ui: Dict["Index"]["ui"];
 	lang: Lang;
 }) {
-	const grad = GRADIENTS[project.gradient] ?? GRADIENTS.aurora;
 	const initials = project.title
 		.replace(/[^A-Za-zА-Яа-я0-9 ]/g, "")
 		.split(" ")
@@ -32,15 +21,15 @@ export default function PortfolioCard({
 
 	return (
 		<div className="card-surface group flex h-full flex-col overflow-hidden rounded-2xl">
-			{/* Gradient cover */}
-			<div className={`relative h-36 overflow-hidden bg-gradient-to-br ${grad}`}>
-				<div className="absolute inset-0 bg-grid opacity-30 mix-blend-overlay" />
-				<div className="absolute inset-0 bg-black/10 transition-opacity duration-300 group-hover:opacity-0" />
-				<span className="absolute left-4 top-4 font-display text-3xl font-bold text-white/90 drop-shadow">
+			{/* Ink cover — big initials, red accent bar on hover */}
+			<div className="relative h-36 overflow-hidden bg-ink">
+				<div className="absolute inset-0 bg-grid opacity-20" />
+				<span className="absolute left-5 top-4 font-display text-4xl font-extrabold text-paper">
 					{initials}
 				</span>
+				<div className="absolute bottom-0 left-0 h-1 w-12 bg-accent transition-all duration-300 group-hover:w-full" />
 				{project.private ? (
-					<span className="absolute right-3 top-3 inline-flex items-center gap-1 rounded-full bg-black/40 px-2.5 py-1 text-[11px] font-semibold text-white backdrop-blur">
+					<span className="absolute right-3 top-3 inline-flex items-center gap-1 rounded-full bg-paper/95 px-2.5 py-1 text-[11px] font-semibold text-ink">
 						<svg
 							xmlns="http://www.w3.org/2000/svg"
 							className="h-3 w-3"
@@ -55,7 +44,7 @@ export default function PortfolioCard({
 			</div>
 
 			<div className="flex flex-1 flex-col p-5">
-				<h3 className="font-display text-lg font-bold text-white">
+				<h3 className="font-display text-lg font-bold text-ink">
 					{project.title}
 				</h3>
 				<p className="mt-2 flex-1 text-sm leading-relaxed text-muted">
@@ -75,7 +64,7 @@ export default function PortfolioCard({
 						href={project.link}
 						target="_blank"
 						rel="noopener"
-						className="mt-4 inline-flex items-center gap-1.5 text-sm font-semibold text-accent-cyan hover:text-white transition-colors"
+						className="mt-4 inline-flex items-center gap-1.5 text-sm font-semibold text-accent hover:text-ink transition-colors"
 					>
 						{ui.visit}
 						<span aria-hidden>↗</span>
@@ -85,7 +74,7 @@ export default function PortfolioCard({
 				{project.caseStudy && (
 					<Link
 						href={`/${lang}/case-studies/${project.slug}`}
-						className="mt-3 inline-block text-sm font-medium text-accent-fuchsia"
+						className="mt-3 inline-block text-sm font-medium text-accent"
 					>
 						{ui.caseStudy} →
 					</Link>

--- a/src/components/skills/skills.tsx
+++ b/src/components/skills/skills.tsx
@@ -33,7 +33,7 @@ export default async function Skills({ lang }: PropsWithLang) {
 									>
 										{group.category.charAt(0)}
 									</span>
-									<h3 className="font-display text-lg font-semibold text-white">
+									<h3 className="font-display text-lg font-semibold text-ink">
 										{group.category}
 									</h3>
 								</div>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -11,19 +11,24 @@ const config: Config = {
 			fontFamily: {
 				sans: ["var(--font-sans)", "system-ui", "sans-serif"],
 				display: ["var(--font-display)", "var(--font-sans)", "sans-serif"],
+				mono: ["var(--font-mono)", "ui-monospace", "monospace"],
 			},
 			colors: {
-				ink: "#0a0a0f",
-				surface: "#12121a",
-				card: "#16161f",
-				line: "#262633",
-				muted: "#9aa0b4",
-				soft: "#6b7088",
+				// Bold Editorial — warm paper + ink + a single red accent.
+				paper: "#f7f5f0",
+				ink: "#0a0a0a",
+				surface: "#ffffff",
+				card: "#ffffff",
+				line: "#e4e0d8",
+				muted: "#57534e",
+				soft: "#8a857d",
 				accent: {
-					DEFAULT: "#8b5cf6",
-					cyan: "#22d3ee",
-					fuchsia: "#e879f9",
-					indigo: "#6366f1",
+					// One red family. cyan/fuchsia/indigo kept as keys so existing
+					// components (text-accent-cyan etc.) re-skin automatically.
+					DEFAULT: "#e11d48",
+					cyan: "#e11d48",
+					fuchsia: "#be123c",
+					indigo: "#e11d48",
 				},
 			},
 			keyframes: {


### PR DESCRIPTION
## Xulosa

Saytni dark/gradient dizayndan **Bold Editorial (oq qog'oz + qizil aksent)** ga o'tkazadi. Faza 1 (Case Studies) ustiga quriladi.

- **Ranglar:** issiq oq qog'oz (#f7f5f0), deyarli qora matn, bitta qizil aksent (#e11d48) — gradient olib tashlandi
- **Tipografiya:** Bricolage Grotesque (display) + IBM Plex Sans (body) + JetBrains Mono (eyebrow/badge — terminal aksent)
- **Komponentlar:** portfolio kartalari ink cover + oq initsial + qizil chiziq; tugmalar qora→qizil hover; eyebrow'lar mono qizil
- **Markaziy:** tailwind tokenlar + globals.css klasslar + layout fontlar. Accent token'lari qizil oilasiga moslandi — komponentlar avtomatik reskin.

## Test Plan
- [x] tsc --noEmit toza
- [x] next build EXIT 0 (17 sahifa)
- [x] Screenshot bilan vizual tasdiq
- [x] 3 til sahifalari 200
- [ ] Mobil responsive (qo'lda)

🤖 Generated with [Claude Code](https://claude.com/claude-code)