### PR TITLE
feat: Maqolalar (blog) — Faza 3

### DIFF
--- a/src/app/[lang]/blog/[slug]/page.tsx
+++ b/src/app/[lang]/blog/[slug]/page.tsx
@@ -1,0 +1,68 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import Reveal from "~/components/reveal/reveal";
+import { getDict } from "~/dict";
+import { getPostBySlug, getAllPostSlugs } from "~/lib/blog";
+import { formatDate } from "~/lib/format-date";
+import { Lang } from "~/types";
+
+export function generateStaticParams() {
+	const langs: Lang[] = ["uz", "ru", "en"];
+	const out: { lang: string; slug: string }[] = [];
+	for (const lang of langs) {
+		for (const slug of getAllPostSlugs()) out.push({ lang, slug });
+	}
+	return out;
+}
+
+export const dynamicParams = false;
+
+export function generateMetadata({ params }: { params: { slug: string } }) {
+	const post = getPostBySlug(params.slug);
+	if (!post) return {};
+	return {
+		title: `${post.title} | Madrimov Xudoshukur`,
+		description: post.description,
+	};
+}
+
+export default async function PostPage({
+	params,
+}: {
+	params: { lang: string; slug: string };
+}) {
+	const lang = params.lang as Lang;
+	const post = getPostBySlug(params.slug);
+	if (!post) notFound();
+	const { ui } = await getDict(lang);
+
+	return (
+		<article className="relative mx-auto max-w-2xl px-5 pt-36 pb-24">
+			<Reveal>
+				<Link href={`/${lang}/blog`} className="section-eyebrow">
+					← {ui.blogTitle}
+				</Link>
+			</Reveal>
+			<Reveal delay={80}>
+				<span className="mt-6 block font-mono text-xs text-soft">
+					{formatDate(post.date, lang)}
+				</span>
+				<h1 className="mt-2 font-display text-3xl sm:text-4xl font-extrabold tracking-tight text-ink">
+					{post.title}
+				</h1>
+				<div className="mt-4 flex flex-wrap gap-1.5">
+					{post.tags.map((t) => (
+						<span key={t} className="tech-badge">
+							{t}
+						</span>
+					))}
+				</div>
+			</Reveal>
+			<Reveal delay={160}>
+				<div className="prose prose-neutral mt-8 max-w-none prose-headings:font-display prose-headings:font-bold prose-a:text-accent prose-strong:text-ink prose-code:text-accent prose-code:before:content-none prose-code:after:content-none">
+					{post.body}
+				</div>
+			</Reveal>
+		</article>
+	);
+}

--- a/src/app/[lang]/blog/page.tsx
+++ b/src/app/[lang]/blog/page.tsx
@@ -1,0 +1,44 @@
+import Link from "next/link";
+import Reveal from "~/components/reveal/reveal";
+import { getDict } from "~/dict";
+import { getPosts } from "~/lib/blog";
+import { PropsWithParams, Lang } from "~/types";
+import { formatDate } from "~/lib/format-date";
+
+export default async function BlogPage({ params }: PropsWithParams) {
+	const lang = params.lang as Lang;
+	const { ui } = await getDict(lang);
+	const posts = getPosts();
+	return (
+		<section className="relative mx-auto max-w-3xl px-5 pt-36 pb-24">
+			<Reveal>
+				<span className="section-eyebrow">{ui.blogTitle}</span>
+			</Reveal>
+			<div className="mt-8 flex flex-col divide-y divide-line">
+				{posts.map((p, i) => (
+					<Reveal key={p.slug} delay={i * 80}>
+						<Link
+							href={`/${lang}/blog/${p.slug}`}
+							className="group block py-7"
+						>
+							<span className="font-mono text-xs text-soft">
+								{formatDate(p.date, lang)}
+							</span>
+							<h2 className="mt-2 font-display text-2xl font-bold text-ink transition-colors group-hover:text-accent">
+								{p.title}
+							</h2>
+							<p className="mt-2 text-muted">{p.description}</p>
+							<div className="mt-3 flex flex-wrap gap-1.5">
+								{p.tags.map((t) => (
+									<span key={t} className="tech-badge">
+										{t}
+									</span>
+								))}
+							</div>
+						</Link>
+					</Reveal>
+				))}
+			</div>
+		</section>
+	);
+}

--- a/src/content/blog/posts.tsx
+++ b/src/content/blog/posts.tsx
@@ -1,0 +1,70 @@
+/* eslint-disable react/no-unescaped-entities */
+import { ReactNode } from "react";
+
+export type BlogPost = {
+	slug: string;
+	title: string;
+	date: string; // ISO, e.g. "2026-06-14"
+	description: string;
+	tags: string[];
+	body: ReactNode;
+};
+
+/**
+ * Maqolalar shu yerda yashaydi (dependency-siz, type-safe).
+ * Yangi post qo'shish: massiv boshiga yangi obyekt qo'shing.
+ * `body` — `prose` ichida render bo'ladigan JSX (h2/p/ul/code/...).
+ */
+export const posts: BlogPost[] = [
+	{
+		slug: "bun-hono-production",
+		title: "Bun + Hono: production'da bir yil",
+		date: "2026-06-14",
+		description:
+			"Node.js'dan Bun + Hono stack'iga o'tish — nima uchun, qanday va qaysi holatlarda ehtiyot bo'lish kerak.",
+		tags: ["Bun", "Hono", "Backend", "Arxitektura"],
+		body: (
+			<>
+				<p>
+					So'nggi bir yil davomida bir nechta production tizimni{" "}
+					<strong>Bun + Hono</strong> stack'ida ishlab chiqdik — maktab boshqaruvi
+					platformasidan kafe raqamlashtirish API'sigacha. Quyida amaliyotdan
+					olingan asosiy xulosalar.
+				</p>
+
+				<h2>Nega Bun?</h2>
+				<p>
+					Asosiy sabab — tezlik va yagona toolchain. <code>bun install</code>{" "}
+					sezilarli tez, test-runner va bundler bitta vositada. Monorepo'da bu
+					ayniqsa seziladi.
+				</p>
+				<ul>
+					<li>Tez o'rnatish va ishga tushirish (cold start past)</li>
+					<li>TypeScript'ni to'g'ridan ishlatish — qo'shimcha build qadami yo'q</li>
+					<li>Node API'lari bilan deyarli to'liq moslik</li>
+				</ul>
+
+				<h2>Nega Hono?</h2>
+				<p>
+					Hono yengil, type-safe va Bun'ga juda mos. Express'ga o'rganib qolganlar
+					uchun o'tish oson, lekin tiplar ancha kuchli — ayniqsa{" "}
+					<code>Drizzle ORM</code> bilan birga.
+				</p>
+
+				<h2>Qaysi holatda ehtiyot bo'lish kerak</h2>
+				<p>
+					Ba'zi keng tarqalgan native paketlar hali Bun'da to'liq sinovdan
+					o'tmagan. Production'ga chiqishdan oldin kritik kutubxonalarni alohida
+					tekshiring va CI'da Bun versiyasini qotirib qo'ying.
+				</p>
+
+				<h2>Xulosa</h2>
+				<p>
+					Yangi loyiha uchun Bun + Hono — kuchli, tez va kelajakka yo'naltirilgan
+					tanlov. Lekin har qanday stack kabi, uni o'z kontekstingizda sinab
+					ko'ring — «ishlasangiz, ishlaydi».
+				</p>
+			</>
+		),
+	},
+];

--- a/src/dict/en.json
+++ b/src/dict/en.json
@@ -6,6 +6,7 @@
       { "href": "/#skills", "title": "Skills" },
       { "href": "/#experience", "title": "Experience" },
       { "href": "/case-studies", "title": "Case Studies" },
+      { "href": "/blog", "title": "Blog" },
       { "href": "/portfolio", "title": "Projects" }
     ],
     "header": {
@@ -205,7 +206,8 @@
       "csSolution": "Solution & architecture",
       "csResults": "Results",
       "csLessons": "What I learned",
-      "caseStudiesTitle": "Case Studies"
+      "caseStudiesTitle": "Case Studies",
+      "blogTitle": "Blog"
     }
   }
 }

--- a/src/dict/index.ts
+++ b/src/dict/index.ts
@@ -88,6 +88,7 @@ type Ui = {
 	csResults: string;
 	csLessons: string;
 	caseStudiesTitle: string;
+	blogTitle: string;
 };
 
 type Index = {

--- a/src/dict/ru.json
+++ b/src/dict/ru.json
@@ -6,6 +6,7 @@
       { "href": "/#skills", "title": "Навыки" },
       { "href": "/#experience", "title": "Опыт" },
       { "href": "/case-studies", "title": "Кейсы" },
+      { "href": "/blog", "title": "Блог" },
       { "href": "/portfolio", "title": "Проекты" }
     ],
     "header": {
@@ -205,7 +206,8 @@
       "csSolution": "Решение и архитектура",
       "csResults": "Результат",
       "csLessons": "Чему я научился",
-      "caseStudiesTitle": "Кейсы"
+      "caseStudiesTitle": "Кейсы",
+      "blogTitle": "Блог"
     }
   }
 }

--- a/src/dict/uz.json
+++ b/src/dict/uz.json
@@ -6,6 +6,7 @@
       { "href": "/#skills", "title": "Ko'nikmalar" },
       { "href": "/#experience", "title": "Tajriba" },
       { "href": "/case-studies", "title": "Case Studies" },
+      { "href": "/blog", "title": "Maqolalar" },
       { "href": "/portfolio", "title": "Loyihalar" }
     ],
     "header": {
@@ -205,7 +206,8 @@
       "csSolution": "Yechim va arxitektura",
       "csResults": "Natija",
       "csLessons": "Nimani o'rgandim",
-      "caseStudiesTitle": "Case Studies"
+      "caseStudiesTitle": "Case Studies",
+      "blogTitle": "Maqolalar"
     }
   }
 }

--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -1,0 +1,16 @@
+import { posts, BlogPost } from "~/content/blog/posts";
+
+/** Barcha postlar, sanasi bo'yicha kamayish tartibida (yangi birinchi) */
+export function getPosts(): BlogPost[] {
+	return [...posts].sort((a, b) => (a.date < b.date ? 1 : -1));
+}
+
+/** slug bo'yicha bitta post; topilmasa null */
+export function getPostBySlug(slug: string): BlogPost | null {
+	return posts.find((p) => p.slug === slug) ?? null;
+}
+
+/** statik generatsiya uchun barcha slug'lar */
+export function getAllPostSlugs(): string[] {
+	return posts.map((p) => p.slug);
+}

--- a/src/lib/format-date.ts
+++ b/src/lib/format-date.ts
@@ -1,0 +1,24 @@
+import { Lang } from "~/types";
+
+const MONTHS: Record<Lang, string[]> = {
+	uz: [
+		"yanvar", "fevral", "mart", "aprel", "may", "iyun",
+		"iyul", "avgust", "sentabr", "oktabr", "noyabr", "dekabr",
+	],
+	ru: [
+		"января", "февраля", "марта", "апреля", "мая", "июня",
+		"июля", "августа", "сентября", "октября", "ноября", "декабря",
+	],
+	en: [
+		"January", "February", "March", "April", "May", "June",
+		"July", "August", "September", "October", "November", "December",
+	],
+};
+
+/** ISO sanani ("2026-06-14") tilga mos formatga aylantiradi. Date'siz (SSR-safe). */
+export function formatDate(iso: string, lang: Lang): string {
+	const [y, m, d] = iso.split("-").map(Number);
+	if (!y || !m || !d) return iso;
+	const month = MONTHS[lang][m - 1] ?? "";
+	return lang === "en" ? `${month} ${d}, ${y}` : `${d}-${month}, ${y}`;
+}


### PR DESCRIPTION
## Xulosa

"Authority Hub"ning oxirgi qismi — **Maqolalar (blog)**. Faza 2 (reskin) ustiga quriladi, editorial styling bilan.

- **Dependency-siz:** pnpm singan muhit uchun TSX-content yondashuvi (MDX/markdown kutubxonasi yo'q). Postlar `src/content/blog/posts.tsx` da type-safe `BlogPost[]` — `prose` ichida render bo'ladigan JSX body.
- **Route'lar:** `/[lang]/blog` (ro'yxat) + `/[lang]/blog/[slug]` (post, SSG, `dynamicParams=false`, 404 himoyasi)
- **i18n:** navbar "Maqolalar/Блог/Blog", sana 3 tilda formatlanadi (`format-date.ts`, Date'siz/SSR-safe). Postlar o'zbek tilida (spec bo'yicha).
- **Styling:** `@tailwindcss/typography` `prose` + editorial override (display sarlavhalar, qizil linklar/code)
- **Namuna post:** "Bun + Hono: production'da bir yil"

## Test Plan
- [x] tsc --noEmit toza
- [x] next build EXIT 0 (20 sahifa, blog SSG × 3 til)
- [x] Screenshot bilan vizual tasdiq (editorial prose)
- [x] list/post 3 tilda 200

## Yangi post qo'shish
`src/content/blog/posts.tsx` massiv boshiga yangi obyekt — slug, title, date, tags, JSX body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)