### PR TITLE
feat: navbar wrap fix + bosh sahifada oxirgi maqolalar

### DIFF
--- a/src/app/[lang]/page.tsx
+++ b/src/app/[lang]/page.tsx
@@ -5,8 +5,11 @@ import Header from "~/components/header/header";
 import MyWork from "~/components/my-work/my-work";
 import Skills from "~/components/skills/skills";
 import Portfolio from "~/components/portfolio/portfolio";
+import LatestPosts from "~/components/latest-posts/latest-posts";
 import { getDict } from "~/dict";
 import { PropsWithParams } from "~/types";
+
+export const revalidate = 300;
 
 export async function generateMetadata({
 	params,
@@ -63,12 +66,13 @@ export default async function Home({ params }: PropsWithParams) {
 			<Skills lang={params.lang} />
 			<Experience lang={params.lang} />
 			<Portfolio lang={params.lang} limit={6} />
-			<div className="mx-auto -mt-8 max-w-5xl px-5 pb-12 text-center sm:text-left">
+			<div className="mx-auto -mt-8 max-w-5xl px-5 text-center sm:text-left">
 				<Link href={`/${params.lang}/portfolio`} className="btn-ghost-line">
 					{portfolio.viewAll}
 					<span aria-hidden>→</span>
 				</Link>
 			</div>
+			<LatestPosts lang={params.lang} limit={3} />
 		</>
 	);
 }

--- a/src/components/latest-posts/latest-posts.tsx
+++ b/src/components/latest-posts/latest-posts.tsx
@@ -1,0 +1,60 @@
+import Link from "next/link";
+import Reveal from "~/components/reveal/reveal";
+import { getDict } from "~/dict";
+import { getPublishedPosts } from "~/lib/notion";
+import { formatDate } from "~/lib/format-date";
+import { Lang } from "~/types";
+
+/** Bosh sahifa uchun eng oxirgi blog postlari (Notion'dan). Post yo'q bo'lsa — render qilinmaydi. */
+export default async function LatestPosts({
+	lang,
+	limit = 3,
+}: {
+	lang: Lang;
+	limit?: number;
+}) {
+	const { ui } = await getDict(lang);
+	const posts = (await getPublishedPosts()).slice(0, limit);
+	if (posts.length === 0) return null;
+
+	return (
+		<section id="blog" className="relative mx-auto max-w-5xl px-5 py-16">
+			<Reveal>
+				<span className="section-eyebrow">{ui.blogTitle}</span>
+			</Reveal>
+			<div className="mt-8 grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
+				{posts.map((p, i) => (
+					<Reveal key={p.slug} delay={i * 80}>
+						<Link
+							href={`/${lang}/blog/${p.slug}`}
+							className="card-surface group flex h-full flex-col rounded-2xl p-6"
+						>
+							<span className="font-mono text-xs text-soft">
+								{formatDate(p.date, lang)}
+							</span>
+							<h3 className="mt-2 font-display text-lg font-bold text-ink transition-colors group-hover:text-accent">
+								{p.title}
+							</h3>
+							<p className="mt-2 flex-1 text-sm text-muted line-clamp-3">
+								{p.description}
+							</p>
+							<div className="mt-3 flex flex-wrap gap-1.5">
+								{p.tags.slice(0, 3).map((t) => (
+									<span key={t} className="tech-badge">
+										{t}
+									</span>
+								))}
+							</div>
+						</Link>
+					</Reveal>
+				))}
+			</div>
+			<div className="mt-8 text-center sm:text-left">
+				<Link href={`/${lang}/blog`} className="btn-ghost-line">
+					{ui.blogTitle}
+					<span aria-hidden>→</span>
+				</Link>
+			</div>
+		</section>
+	);
+}

--- a/src/components/navbar/navbar.tsx
+++ b/src/components/navbar/navbar.tsx
@@ -28,7 +28,7 @@ export default function Navbar({ items }: { items: MenuItem[] }) {
 	return (
 		<div className="fixed top-0 inset-x-0 z-50 flex justify-center px-3 lg:px-0">
 			<nav
-				className={`mt-4 w-full max-w-3xl rounded-2xl glass transition-all duration-300 ${
+				className={`mt-4 w-full max-w-5xl rounded-2xl glass transition-all duration-300 ${
 					scrolled ? "shadow-[0_10px_40px_-18px_rgba(225,29,72,0.28)]" : ""
 				}`}
 			>
@@ -42,12 +42,12 @@ export default function Navbar({ items }: { items: MenuItem[] }) {
 					</Link>
 
 					{/* Desktop menu */}
-					<ul className="hidden md:flex items-center gap-1 text-sm font-medium">
+					<ul className="hidden md:flex items-center gap-0.5 text-sm font-medium">
 						{items.map((item) => (
 							<li key={item.href}>
 								<Link
 									href={`/${lang}${item.href}`}
-									className="px-3 py-2 rounded-lg text-muted hover:text-ink hover:bg-black/[0.03] transition-colors"
+									className="block whitespace-nowrap px-2.5 py-2 rounded-lg text-muted hover:text-ink hover:bg-black/[0.03] transition-colors"
 								>
 									{item.title}
 								</Link>


### PR DESCRIPTION
## O'zgarishlar
1. **Navbar (uz)** — o'zbekcha 7 nav item ikki qatorga tushib qolardi. Navbar `max-w-3xl`→`max-w-5xl`, nav linklarga `whitespace-nowrap` — endi bir qatorda.
2. **Bosh sahifa** — Portfolio'dan keyin "Maqolalar" bo'limi: eng oxirgi 3 ta Notion post kartochkasi + "Maqolalar →" link. ISR (revalidate=300).

## Test
- [x] tsc toza, build EXIT 0 (23 sahifa)
- [x] Screenshot: navbar bir qatorda, blog bo'limi render

🤖 Generated with [Claude Code](https://claude.com/claude-code)