### PR TITLE
feat: loyihalar i18n (Lang + o'zbek fallback)

### DIFF
--- a/src/app/[lang]/case-studies/[slug]/page.tsx
+++ b/src/app/[lang]/case-studies/[slug]/page.tsx
@@ -10,22 +10,22 @@ export const revalidate = 300;
 export const dynamicParams = true;
 
 export async function generateStaticParams() {
-	const items = (await getProjects()).filter((p) => p.hasCaseStudy);
+	const items = (await getProjects("uz")).filter((p) => p.hasCaseStudy);
 	const langs: Lang[] = ["uz", "ru", "en"];
 	const out: { lang: string; slug: string }[] = [];
 	for (const lang of langs) for (const p of items) out.push({ lang, slug: p.slug });
 	return out;
 }
 
-export async function generateMetadata({ params }: { params: { slug: string } }) {
-	const project = await getProjectBySlug(params.slug);
+export async function generateMetadata({ params }: { params: { lang: string; slug: string } }) {
+	const project = await getProjectBySlug(params.lang as Lang, params.slug);
 	if (!project || !project.hasCaseStudy) return {};
 	return { title: `${project.title} — Case Study | Madrimov Xudoshukur`, description: project.description };
 }
 
 export default async function Page({ params }: { params: { lang: string; slug: string } }) {
 	const lang = params.lang as Lang;
-	const project = await getProjectBySlug(params.slug);
+	const project = await getProjectBySlug(lang, params.slug);
 	if (!project || !project.hasCaseStudy) notFound();
 	const { ui } = await getDict(lang);
 	const blocks = await getProjectBlocks(project.id);

--- a/src/app/[lang]/case-studies/page.tsx
+++ b/src/app/[lang]/case-studies/page.tsx
@@ -9,7 +9,7 @@ export const revalidate = 300;
 export default async function CaseStudiesPage({ params }: PropsWithParams) {
 	const lang = params.lang as Lang;
 	const { ui } = await getDict(lang);
-	const items = (await getProjects()).filter((p) => p.hasCaseStudy);
+	const items = (await getProjects(lang)).filter((p) => p.hasCaseStudy);
 	return (
 		<section className="relative mx-auto max-w-5xl px-5 pt-36 pb-24">
 			<Reveal><span className="section-eyebrow">{ui.caseStudiesTitle}</span></Reveal>

--- a/src/components/portfolio/portfolio.tsx
+++ b/src/components/portfolio/portfolio.tsx
@@ -10,7 +10,7 @@ export default async function Portfolio({
 	standalone = false,
 }: PropsWithLang & { limit?: number; standalone?: boolean }) {
 	const { portfolio, ui } = await getDict(lang);
-	let projects = await getProjects();
+	let projects = await getProjects(lang);
 	if (typeof limit === "number") projects = projects.slice(0, limit);
 
 	return (

--- a/src/lib/notion.ts
+++ b/src/lib/notion.ts
@@ -72,6 +72,8 @@ export type ProjectMeta = {
 	private: boolean;
 	cover?: string;
 	hasCaseStudy: boolean;
+	lang: string;
+	order: number;
 };
 
 function fileUrl(filesProp: any): string | undefined {
@@ -93,10 +95,12 @@ function toProject(page: any): ProjectMeta {
 		private: p.Private?.checkbox ?? false,
 		cover: fileUrl(p.Cover),
 		hasCaseStudy: p.HasCaseStudy?.checkbox ?? false,
+		lang: p.Lang?.select?.name || "uz",
+		order: p.Order?.number ?? 0,
 	};
 }
 
-export const getProjects = cache(async (): Promise<ProjectMeta[]> => {
+const getRawProjects = cache(async (): Promise<ProjectMeta[]> => {
 	if (!TOKEN || !PROJECTS_DB_ID) return [];
 	const projects: ProjectMeta[] = [];
 	let cursor: string | undefined;
@@ -107,7 +111,6 @@ export const getProjects = cache(async (): Promise<ProjectMeta[]> => {
 				headers: headers(),
 				body: JSON.stringify({
 					filter: { property: "Published", checkbox: { equals: true } },
-					sorts: [{ property: "Order", direction: "ascending" }],
 					...(cursor ? { start_cursor: cursor } : {}),
 				}),
 				next: { revalidate: 300 },
@@ -123,9 +126,27 @@ export const getProjects = cache(async (): Promise<ProjectMeta[]> => {
 	return projects;
 });
 
-export async function getProjectBySlug(slug: string): Promise<ProjectMeta | null> {
-	const projects = await getProjects();
-	return projects.find((p) => p.slug === slug) ?? null;
+function pickLang(rows: ProjectMeta[], lang: string): ProjectMeta {
+	return rows.find((r) => r.lang === lang) ?? rows.find((r) => r.lang === "uz") ?? rows[0];
+}
+
+export async function getProjects(lang: string): Promise<ProjectMeta[]> {
+	const raw = await getRawProjects();
+	const bySlug = new Map<string, ProjectMeta[]>();
+	for (const p of raw) {
+		const arr = bySlug.get(p.slug) ?? [];
+		arr.push(p);
+		bySlug.set(p.slug, arr);
+	}
+	return Array.from(bySlug.values())
+		.map((rows) => pickLang(rows, lang))
+		.sort((a, b) => a.order - b.order);
+}
+
+export async function getProjectBySlug(lang: string, slug: string): Promise<ProjectMeta | null> {
+	const raw = (await getRawProjects()).filter((p) => p.slug === slug);
+	if (raw.length === 0) return null;
+	return pickLang(raw, lang);
 }
 
 /** Case study body bloklari — mavjud getBlocks qayta ishlatiladi */


### PR DESCRIPTION
## Xulosa
Notion "Projects" loyihalariga til qo'llab-quvvatlash. Tanlangan tilda qator bo'lmasa — o'zbekka fallback (sahifa hech qachon bo'sh qolmaydi).

- Notion'ga `Lang` Select ustuni (uz/ru/en); mavjud 7 qator → uz
- `getProjects(lang)` / `getProjectBySlug(lang, slug)` — slug bo'yicha guruhlab, lang yoki uz qatorini tanlaydi (`pickLang`)
- `getRawProjects` (React.cache) + `ProjectMeta` ga `lang`/`order`
- Komponentlar `lang` uzatadi (route'larda bor)

## Test
- [x] tsc + build EXIT 0
- [x] Fallback: ru/portfolio → uz kontent (ru qatori yo'q), ru case-study → uz body

## Yangi til qo'shish
Notion'da yangi qator: Slug bir xil, Lang=ru/en, tarjima, Published ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)