### PR TITLE
feat: blog i18n (Lang + o'zbek fallback)

### DIFF
--- a/src/app/[lang]/blog/[slug]/page.tsx
+++ b/src/app/[lang]/blog/[slug]/page.tsx
@@ -11,15 +11,15 @@ export const revalidate = 300;
 export const dynamicParams = true;
 
 export async function generateStaticParams() {
-	const posts = await getPublishedPosts();
+	const posts = await getPublishedPosts("uz");
 	const langs: Lang[] = ["uz", "ru", "en"];
 	const out: { lang: string; slug: string }[] = [];
 	for (const lang of langs) for (const p of posts) out.push({ lang, slug: p.slug });
 	return out;
 }
 
-export async function generateMetadata({ params }: { params: { slug: string } }) {
-	const post = await getPostBySlug(params.slug);
+export async function generateMetadata({ params }: { params: { lang: string; slug: string } }) {
+	const post = await getPostBySlug(params.lang as Lang, params.slug);
 	if (!post) return {};
 	return {
 		title: `${post.title} | Madrimov Xudoshukur`,
@@ -33,7 +33,7 @@ export default async function PostPage({
 	params: { lang: string; slug: string };
 }) {
 	const lang = params.lang as Lang;
-	const post = await getPostBySlug(params.slug);
+	const post = await getPostBySlug(lang, params.slug);
 	if (!post) notFound();
 	const { ui } = await getDict(lang);
 	const blocks = await getBlocks(post.id);

--- a/src/app/[lang]/blog/page.tsx
+++ b/src/app/[lang]/blog/page.tsx
@@ -10,7 +10,7 @@ export const revalidate = 300;
 export default async function BlogPage({ params }: PropsWithParams) {
 	const lang = params.lang as Lang;
 	const { ui } = await getDict(lang);
-	const posts = await getPublishedPosts();
+	const posts = await getPublishedPosts(lang);
 	return (
 		<section className="relative mx-auto max-w-3xl px-5 pt-36 pb-24">
 			<Reveal>

--- a/src/components/latest-posts/latest-posts.tsx
+++ b/src/components/latest-posts/latest-posts.tsx
@@ -14,7 +14,7 @@ export default async function LatestPosts({
 	limit?: number;
 }) {
 	const { ui } = await getDict(lang);
-	const posts = (await getPublishedPosts()).slice(0, limit);
+	const posts = (await getPublishedPosts(lang)).slice(0, limit);
 	if (posts.length === 0) return null;
 
 	return (

--- a/src/lib/notion.ts
+++ b/src/lib/notion.ts
@@ -24,10 +24,11 @@ function toMeta(page: any): BlogPostMeta {
 		description: plain(p.Description?.rich_text),
 		date: p.Date?.date?.start ?? "",
 		tags: (p.Tags?.multi_select ?? []).map((t: any) => t.name),
+		lang: p.Lang?.select?.name || "uz",
 	};
 }
 
-export async function getPublishedPosts(): Promise<BlogPostMeta[]> {
+const getRawPosts = cache(async (): Promise<BlogPostMeta[]> => {
 	if (!TOKEN || !DB_ID) return [];
 	const posts: BlogPostMeta[] = [];
 	let cursor: string | undefined;
@@ -52,11 +53,26 @@ export async function getPublishedPosts(): Promise<BlogPostMeta[]> {
 		/* bo'sh/qisman qaytadi */
 	}
 	return posts;
+});
+
+/** lang qatori, yo'q bo'lsa uz fallback; Date desc tartibida */
+export async function getPublishedPosts(lang: string): Promise<BlogPostMeta[]> {
+	const raw = await getRawPosts();
+	const bySlug = new Map<string, BlogPostMeta[]>();
+	for (const p of raw) {
+		const arr = bySlug.get(p.slug) ?? [];
+		arr.push(p);
+		bySlug.set(p.slug, arr);
+	}
+	return Array.from(bySlug.values())
+		.map((rows) => pickLang(rows, lang))
+		.sort((a, b) => (a.date < b.date ? 1 : -1));
 }
 
-export async function getPostBySlug(slug: string): Promise<BlogPostMeta | null> {
-	const posts = await getPublishedPosts();
-	return posts.find((p) => p.slug === slug) ?? null;
+export async function getPostBySlug(lang: string, slug: string): Promise<BlogPostMeta | null> {
+	const raw = (await getRawPosts()).filter((p) => p.slug === slug);
+	if (raw.length === 0) return null;
+	return pickLang(raw, lang);
 }
 
 const PROJECTS_DB_ID = process.env.NOTION_PROJECTS_DB_ID;
@@ -126,7 +142,7 @@ const getRawProjects = cache(async (): Promise<ProjectMeta[]> => {
 	return projects;
 });
 
-function pickLang(rows: ProjectMeta[], lang: string): ProjectMeta {
+function pickLang<T extends { lang: string }>(rows: T[], lang: string): T {
 	return rows.find((r) => r.lang === lang) ?? rows.find((r) => r.lang === "uz") ?? rows[0];
 }
 

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -17,4 +17,5 @@ export type BlogPostMeta = {
 	description: string;
 	date: string;
 	tags: string[];
+	lang: string;
 };


### PR DESCRIPTION
Loyihalardagi bilan bir xil i18n pattern blog'ga. Blog Posts DB ga `Lang` ustuni, `getPublishedPosts(lang)`/`getPostBySlug(lang,slug)` uz-fallback (`pickLang` generic). Mavjud 3 post → uz.

Test: tsc + build EXIT 0; ru/blog → uz fallback (ru post yo'q), ru post 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)