### PR TITLE
fix: Signal glass rang izchilligi + mobil hero

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -34,13 +34,15 @@
 @layer components {
 	/* ===================== Signal core classes ===================== */
 
-	/* Frosted glass surface (skills/cards) */
+	/* Frosted glass surface (skills/cards) — opaque dark base so the fixed
+	   aurora never bleeds through unevenly; keeps cards/text consistent. */
 	.glass {
 		background: linear-gradient(
-			180deg,
-			rgba(255, 255, 255, 0.06),
-			rgba(255, 255, 255, 0.025)
-		);
+				180deg,
+				rgba(255, 255, 255, 0.05),
+				rgba(255, 255, 255, 0.02)
+			),
+			rgba(13, 15, 18, 0.88);
 		border: 1px solid rgba(255, 255, 255, 0.1);
 		backdrop-filter: blur(14px) saturate(130%);
 		-webkit-backdrop-filter: blur(14px) saturate(130%);
@@ -51,10 +53,11 @@
 	/* Stronger glass for prominent cards/panels */
 	.glass-strong {
 		background: linear-gradient(
-			180deg,
-			rgba(255, 255, 255, 0.06),
-			rgba(255, 255, 255, 0.025)
-		);
+				180deg,
+				rgba(255, 255, 255, 0.06),
+				rgba(255, 255, 255, 0.025)
+			),
+			rgba(15, 17, 20, 0.9);
 		border: 1px solid rgba(255, 255, 255, 0.1);
 		backdrop-filter: blur(16px) saturate(135%);
 		-webkit-backdrop-filter: blur(16px) saturate(135%);

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -57,7 +57,7 @@ export default async function Header({ lang }: PropsWithLang) {
 						{header.kicker}
 					</div>
 
-					<h1 className="m-0 font-display font-extrabold leading-[.88] tracking-[-.04em] text-[clamp(54px,7.6vw,108px)]">
+					<h1 className="m-0 font-display font-extrabold leading-[.88] tracking-[-.04em] text-[clamp(34px,11vw,108px)] break-words">
 						MADRIMOV
 					</h1>
 					<h1 className="mt-1.5 font-display font-light leading-none tracking-[-.01em] text-[#7e848c] text-[clamp(26px,3.6vw,52px)]">


### PR DESCRIPTION
Signal redizaynidan keyingi 2 tuzatish:
1. **Glass rang nomuvofiqligi** — `.glass`/`.glass-strong` shaffof edi, fixed aurora ortidan notekis ko'rinib kartalar/matn turli rangda chiqardi. Endi opaque dark base qo'shildi → kartalar va matn barcha bo'limlarda izchil.
2. **Mobil hero overflow** — "MADRIMOV" clamp min 54px juda katta edi (mobil ekrandan chiqardi). 34px min + 11vw + break-words → mobil'da to'liq sig'adi.

Screenshot bilan tasdiqlandi (desktop experience izchil, mobil hero sig'adi). tsc + build EXIT 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)