### PR TITLE
fix: qora matn (base token), classic </> logo, mobil til compact

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -36,7 +36,7 @@ export default async function RootLayout({
 			lang="en"
 			className={`h-full ${display.variable} ${sans.variable} ${mono.variable}`}
 		>
-			<body className="font-sans bg-base text-fg antialiased">
+			<body className="font-sans bg-night text-fg antialiased">
 				{children}
 				<Analytics />
 			</body>

--- a/src/components/footer/footer.tsx
+++ b/src/components/footer/footer.tsx
@@ -52,9 +52,7 @@ export default function Footer() {
 
 				<div className="flex flex-wrap items-center justify-between gap-6 pt-8">
 					<div className="flex items-center gap-[11px]">
-						<span className="flex h-[30px] w-[30px] items-center justify-center rounded-lg border-[1.5px] border-accent font-display text-xs font-bold text-accent">
-							MX
-						</span>
+						<span className="font-mono text-xl font-bold text-accent">{`</>`}</span>
 						<span className="font-mono text-[13px] text-[#888E96]">
 							© 2026 Madrimov Xudoshukur
 						</span>

--- a/src/components/navbar/navbar.tsx
+++ b/src/components/navbar/navbar.tsx
@@ -34,12 +34,7 @@ export default function Navbar({ items }: { items: MenuItem[] }) {
 					href={`/${lang}`}
 					className="flex items-center gap-[11px] select-none"
 				>
-					<span className="flex h-[34px] w-[34px] items-center justify-center rounded-[9px] border-[1.5px] border-accent font-display text-sm font-bold text-accent">
-						MX
-					</span>
-					<span className="font-display text-base font-medium tracking-[-.01em] text-fg">
-						madrimov<span className="text-accent">.uz</span>
-					</span>
+					<span className="font-mono text-2xl font-bold text-accent">{`</>`}</span>
 				</Link>
 
 				{/* Desktop menu */}
@@ -71,7 +66,7 @@ export default function Navbar({ items }: { items: MenuItem[] }) {
 										`/${l}${locale ? `/${locale.replace(/^\//, "")}` : ""}`
 									)
 								}
-								className={`rounded-full px-3 py-1 text-xs uppercase tracking-[.04em] transition-colors ${
+								className={`rounded-full px-2 py-1 text-[11px] uppercase tracking-[.04em] transition-colors sm:px-3 sm:text-xs ${
 									lang === l
 										? "bg-accent font-semibold text-surface"
 										: "text-[#888E96] hover:text-fg"

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -15,7 +15,9 @@ const config: Config = {
 			},
 			colors: {
 				// === Signal dark palette ===
-				base: "#070611",
+				// NOTE: do NOT name a color "base" — it collides with Tailwind's
+				// `text-base` font-size utility and turns 16px text black.
+				night: "#070611",
 				surface: "#0B0C0E",
 				surface2: "#0E1013",
 				surface3: "#141619",


### PR DESCRIPTION
3 tuzatish:
1. **Qora matn** — `colors.base` Tailwind `text-base` (16px) utilitysi bilan to'qnashib, 16px matnni qora qilardi. Token `base`→`night` ga nomlandi.
2. **Logo** — navbar va footer'da MX kvadrat + madrimov.uz o'rniga classic `</>` qaytarildi.
3. **Mobil til** — UZ/RU/EN switcher mobil'da compact (kichik pill) → navbar sig'adi, gorizontal overflow 0px.

Screenshot bilan tasdiqlandi (desktop+mobil). tsc + build EXIT 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)