### PR TITLE
perf(signal): cut idle GPU load from aurora + hero canvas

### DIFF
--- a/src/components/aurora/aurora.tsx
+++ b/src/components/aurora/aurora.tsx
@@ -2,8 +2,14 @@
  * Aurora backdrop — fixed full-screen, behind all content.
  *
  * Serious, muted Signal palette: a deep graphite radial base plus three large
- * blurred slate/graphite circles that slowly drift (sgAuroraA/B/C). Strictly
- * decorative — pointer-events:none, no interactivity. Server component.
+ * blurred slate/graphite circles. Strictly decorative — pointer-events:none,
+ * no interactivity. Server component.
+ *
+ * Performance: the circles are STATIC (no drift animation). Animating
+ * `transform` on a blur(90px) layer forces a full-screen re-rasterisation every
+ * frame — the dominant GPU cost on this page. Static blurred gradients are
+ * rasterised once and composited cheaply. Blur is also reduced to 60px (cheaper
+ * to rasterise) with no perceptible visual change at this opacity.
  *
  * Ported from signal.dc.html lines 34-38.
  */
@@ -18,7 +24,7 @@ export default function Aurora() {
 			}}
 		>
 			<div
-				className="absolute rounded-full animate-sgAuroraA"
+				className="absolute rounded-full"
 				style={{
 					top: "-16%",
 					left: "-12%",
@@ -26,11 +32,11 @@ export default function Aurora() {
 					height: "66vw",
 					background:
 						"radial-gradient(circle,rgba(48,60,78,.34),transparent 64%)",
-					filter: "blur(90px)",
+					filter: "blur(60px)",
 				}}
 			/>
 			<div
-				className="absolute rounded-full animate-sgAuroraB"
+				className="absolute rounded-full"
 				style={{
 					top: "10%",
 					right: "-18%",
@@ -38,11 +44,11 @@ export default function Aurora() {
 					height: "62vw",
 					background:
 						"radial-gradient(circle,rgba(40,50,64,.3),transparent 65%)",
-					filter: "blur(92px)",
+					filter: "blur(60px)",
 				}}
 			/>
 			<div
-				className="absolute rounded-full animate-sgAuroraC"
+				className="absolute rounded-full"
 				style={{
 					bottom: "-22%",
 					left: "28%",
@@ -50,7 +56,7 @@ export default function Aurora() {
 					height: "60vw",
 					background:
 						"radial-gradient(circle,rgba(34,42,54,.34),transparent 64%)",
-					filter: "blur(96px)",
+					filter: "blur(60px)",
 				}}
 			/>
 		</div>

--- a/src/components/signal-effects/signal-effects.tsx
+++ b/src/components/signal-effects/signal-effects.tsx
@@ -19,7 +19,8 @@ import { useEffect, useState } from "react";
  *   - hero cursor spotlight (#hero / #hero-spot);
  *   - scroll-reveal for the main sections (IntersectionObserver), respecting
  *     prefers-reduced-motion;
- *   - architecture network canvas (#hero-canvas), 36 nodes / 150px links.
+ *   - architecture network canvas (#hero-canvas), 22 nodes / 140px links,
+ *     capped at 30fps and paused when off-screen / tab hidden / reduced-motion.
  *
  * Everything is torn down in the effect cleanup.
  */
@@ -163,9 +164,9 @@ export default function SignalEffects() {
 		) as HTMLCanvasElement | null;
 		const host = document.getElementById("hero");
 		const ctx = canvas?.getContext("2d") ?? null;
-		if (canvas && host && ctx) {
-			const COUNT = 36;
-			const LINK = 150;
+		if (canvas && host && ctx && !reduceMotion) {
+			const COUNT = 22;
+			const LINK = 140;
 			type Node = {
 				x: number;
 				y: number;
@@ -178,6 +179,9 @@ export default function SignalEffects() {
 			let nodes: Node[] = [];
 			let wh = { w: 0, h: 0 };
 			let raf = 0;
+			let last = 0;
+			let visible = true;
+			const FRAME = 1000 / 30; // cap at 30fps to halve GPU/CPU load
 
 			const init = () => {
 				const w = host.clientWidth;
@@ -199,6 +203,11 @@ export default function SignalEffects() {
 			};
 
 			const draw = (t: number) => {
+				raf = requestAnimationFrame(draw);
+				// skip work when off-screen / tab hidden, and throttle to ~30fps
+				if (!visible) return;
+				if (t - last < FRAME) return;
+				last = t;
 				const w = wh.w;
 				const h = wh.h;
 				ctx.clearRect(0, 0, w, h);
@@ -235,16 +244,38 @@ export default function SignalEffects() {
 						: "rgba(155,165,175," + (0.22 * pulse + 0.12).toFixed(3) + ")";
 					ctx.fill();
 				}
-				raf = requestAnimationFrame(draw);
+			};
+
+			let heroVisible = true;
+			const syncVisible = () => {
+				visible = !document.hidden && heroVisible;
 			};
 
 			init();
 			raf = requestAnimationFrame(draw);
 			const onResize = () => init();
 			window.addEventListener("resize", onResize);
+			document.addEventListener("visibilitychange", syncVisible);
+
+			// Pause the loop when the hero scrolls off-screen — no point burning
+			// GPU on a network the user can't see.
+			let heroIo: IntersectionObserver | null = null;
+			if ("IntersectionObserver" in window) {
+				heroIo = new IntersectionObserver(
+					(entries) => {
+						heroVisible = entries[0]?.isIntersecting ?? true;
+						syncVisible();
+					},
+					{ threshold: 0 }
+				);
+				heroIo.observe(host);
+			}
+
 			cleanups.push(() => {
 				cancelAnimationFrame(raf);
 				window.removeEventListener("resize", onResize);
+				document.removeEventListener("visibilitychange", syncVisible);
+				heroIo?.disconnect();
 			});
 		}
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -84,21 +84,6 @@ const config: Config = {
 					"0%": { transform: "translateX(-120%) skewX(-18deg)" },
 					"100%": { transform: "translateX(320%) skewX(-18deg)" },
 				},
-				sgAuroraA: {
-					"0%": { transform: "translate(0,0) scale(1)" },
-					"50%": { transform: "translate(6vw,4vh) scale(1.18)" },
-					"100%": { transform: "translate(0,0) scale(1)" },
-				},
-				sgAuroraB: {
-					"0%": { transform: "translate(0,0) scale(1.1)" },
-					"50%": { transform: "translate(-7vw,-5vh) scale(1)" },
-					"100%": { transform: "translate(0,0) scale(1.1)" },
-				},
-				sgAuroraC: {
-					"0%": { transform: "translate(0,0) scale(1)" },
-					"50%": { transform: "translate(5vw,-6vh) scale(1.22)" },
-					"100%": { transform: "translate(0,0) scale(1)" },
-				},
 
 				// === Legacy keyframes kept so existing animate-* usages keep working ===
 				"fade-up": {
@@ -126,9 +111,6 @@ const config: Config = {
 				sgIntroOut: "sgIntroOut 1.9s cubic-bezier(.7,0,.2,1) forwards",
 				sgIntroBar: "sgIntroBar 1.2s ease forwards",
 				sgSheen: "sgSheen 1.1s ease forwards",
-				sgAuroraA: "sgAuroraA 40s ease-in-out infinite",
-				sgAuroraB: "sgAuroraB 46s ease-in-out infinite",
-				sgAuroraC: "sgAuroraC 52s ease-in-out infinite",
 
 				// === Legacy animations kept ===
 				"fade-up": "fade-up 0.7s cubic-bezier(0.22,1,0.36,1) both",


### PR DESCRIPTION
## Muammo
Signal hero saytni ochganda GPU'ni ~50% da ushlab turardi (foydalanuvchi shikoyati). Sabab — ikkita og'ir effekt, ikkalasi ham **idle holatda** (scroll/interaksiyasiz) yuk berardi.

## O'zgarishlar

**Aurora (`aurora.tsx`)**
- 3 ta to'liq-ekran `blur(90-96px)` qatlami `transform/scale` orqali animatsiya qilinardi → har frame'da ulkan blur sirtni qayta-rasterizatsiya qilishga majburlardi (asosiy GPU narxi).
- Doiralar endi **statik** (drift yo'q), blur **60px** ga tushirildi → bir marta rasterizatsiya, arzon kompozit. `.3-.34` shaffoflikda vizual farq sezilmaydi.
- Ishlatilmay qolgan `sgAuroraA/B/C` keyframe + animatsiyalar olib tashlandi (`tailwind.config.ts`).

**Hero canvas (`signal-effects.tsx`)**
- Tarmoq chizish sikli **30fps** ga cheklandi.
- Hero ekrandan chiqsa (`IntersectionObserver`) yoki tab yashirilsa (`visibilitychange`) sikl **to'xtatiladi**.
- `prefers-reduced-motion` da canvas umuman ishlamaydi.
- Tugun soni 36→22, bog'lanish radiusi 150→140.

## Tekshirildi
- `next build` — EXIT 0, 23 sahifa generatsiya qilindi.
- Brauzerda (`next dev`) vizual tasdiqlandi: hero sarlavhasi, tarmoq nuqtalari, aurora porlashi va glass kartalar avvalgidek ko'rinadi.
- Yagona console xato — `site.webmanifest` (oldindan mavjud, bu o'zgarishga aloqasiz).

## Qoldirilgan (ataylab)
Navbar `backdrop-blur-[36px]` o'zgartirilmadi — u **scroll vaqtidagi** narx, bu PR esa idle/ochilish narxini hal qiladi. Agar keyinchalik scroll paytida jank bo'lsa, keyingi lever shu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)