### PR TITLE
feat(seo): ideal SEO — sitemap, robots, canonical/hreflang, JSON-LD

### DIFF
--- a/src/app/[lang]/blog/[slug]/page.tsx
+++ b/src/app/[lang]/blog/[slug]/page.tsx
@@ -1,11 +1,20 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import Reveal from "~/components/reveal/reveal";
+import JsonLd from "~/components/json-ld/json-ld";
 import { getDict } from "~/dict";
 import { getPublishedPosts, getPostBySlug, getBlocks } from "~/lib/notion";
 import { renderBlocks } from "~/lib/notion-render";
 import { formatDate } from "~/lib/format-date";
 import { Lang } from "~/types";
+import {
+	SITE_URL,
+	SITE_NAME,
+	OG_LOCALE,
+	PERSON_ID,
+	alternates,
+	pageUrl,
+} from "~/lib/seo";
 
 export const revalidate = 300;
 export const dynamicParams = true;
@@ -19,11 +28,27 @@ export async function generateStaticParams() {
 }
 
 export async function generateMetadata({ params }: { params: { lang: string; slug: string } }) {
-	const post = await getPostBySlug(params.lang as Lang, params.slug);
+	const lang = params.lang as Lang;
+	const post = await getPostBySlug(lang, params.slug);
 	if (!post) return {};
+	const suffix = `/blog/${post.slug}`;
 	return {
-		title: `${post.title} | Madrimov Xudoshukur`,
+		title: post.title,
 		description: post.description,
+		keywords: post.tags,
+		alternates: alternates(lang, suffix),
+		openGraph: {
+			type: "article",
+			locale: OG_LOCALE[lang],
+			url: pageUrl(lang, suffix),
+			title: post.title,
+			description: post.description,
+			siteName: `${SITE_NAME} Portfolio`,
+			publishedTime: post.date,
+			authors: ["Xudoshukur Madrimov"],
+			tags: post.tags,
+			images: [{ url: "/avatar.jpg", alt: post.title }],
+		},
 	};
 }
 
@@ -38,8 +63,31 @@ export default async function PostPage({
 	const { ui } = await getDict(lang);
 	const blocks = await getBlocks(post.id);
 
+	const suffix = `/blog/${post.slug}`;
+	const url = pageUrl(lang, suffix);
+	const articleLd = {
+		"@context": "https://schema.org",
+		"@type": "BlogPosting",
+		"@id": `${url}#article`,
+		mainEntityOfPage: url,
+		headline: post.title,
+		description: post.description,
+		inLanguage: lang,
+		datePublished: post.date,
+		dateModified: post.date,
+		image: `${SITE_URL}/avatar.jpg`,
+		keywords: post.tags.join(", "),
+		author: { "@type": "Person", "@id": PERSON_ID, name: "Xudoshukur Madrimov" },
+		publisher: {
+			"@type": "Person",
+			"@id": PERSON_ID,
+			name: "Xudoshukur Madrimov",
+		},
+	};
+
 	return (
 		<article className="relative mx-auto max-w-2xl px-5 pt-36 pb-24">
+			<JsonLd data={articleLd} />
 			<Reveal>
 				<Link href={`/${lang}/blog`} className="section-eyebrow">
 					← {ui.blogTitle}

--- a/src/app/[lang]/blog/page.tsx
+++ b/src/app/[lang]/blog/page.tsx
@@ -1,11 +1,37 @@
+import { Metadata } from "next";
 import Link from "next/link";
 import Reveal from "~/components/reveal/reveal";
 import { getDict } from "~/dict";
 import { getPublishedPosts } from "~/lib/notion";
 import { PropsWithParams, Lang } from "~/types";
 import { formatDate } from "~/lib/format-date";
+import { SITE_NAME, OG_LOCALE, alternates, pageUrl } from "~/lib/seo";
 
 export const revalidate = 300;
+
+const BLOG_DESC: Record<Lang, string> = {
+	uz: "Backend, arxitektura, DevOps va production muhandisligi haqida Xudoshukur Madrimov bloglari.",
+	ru: "Блог Худошукура Мадримова о бэкенде, архитектуре, DevOps и продакшн-инженерии.",
+	en: "Articles by Xudoshukur Madrimov on backend, architecture, DevOps and production engineering.",
+};
+
+export async function generateMetadata({ params }: PropsWithParams): Promise<Metadata> {
+	const { ui } = await getDict(params.lang);
+	const suffix = "/blog";
+	return {
+		title: ui.blogTitle,
+		description: BLOG_DESC[params.lang],
+		alternates: alternates(params.lang, suffix),
+		openGraph: {
+			type: "website",
+			locale: OG_LOCALE[params.lang],
+			url: pageUrl(params.lang, suffix),
+			title: ui.blogTitle,
+			description: BLOG_DESC[params.lang],
+			siteName: `${SITE_NAME} Portfolio`,
+		},
+	};
+}
 
 export default async function BlogPage({ params }: PropsWithParams) {
 	const lang = params.lang as Lang;

--- a/src/app/[lang]/case-studies/[slug]/page.tsx
+++ b/src/app/[lang]/case-studies/[slug]/page.tsx
@@ -1,10 +1,19 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import Reveal from "~/components/reveal/reveal";
+import JsonLd from "~/components/json-ld/json-ld";
 import { getDict } from "~/dict";
 import { getProjects, getProjectBySlug, getProjectBlocks } from "~/lib/notion";
 import { renderBlocks } from "~/lib/notion-render";
 import { Lang } from "~/types";
+import {
+	SITE_URL,
+	SITE_NAME,
+	OG_LOCALE,
+	PERSON_ID,
+	alternates,
+	pageUrl,
+} from "~/lib/seo";
 
 export const revalidate = 300;
 export const dynamicParams = true;
@@ -18,9 +27,25 @@ export async function generateStaticParams() {
 }
 
 export async function generateMetadata({ params }: { params: { lang: string; slug: string } }) {
-	const project = await getProjectBySlug(params.lang as Lang, params.slug);
+	const lang = params.lang as Lang;
+	const project = await getProjectBySlug(lang, params.slug);
 	if (!project || !project.hasCaseStudy) return {};
-	return { title: `${project.title} — Case Study | Madrimov Xudoshukur`, description: project.description };
+	const suffix = `/case-studies/${project.slug}`;
+	return {
+		title: `${project.title} — Case Study`,
+		description: project.description,
+		keywords: project.tags,
+		alternates: alternates(lang, suffix),
+		openGraph: {
+			type: "article",
+			locale: OG_LOCALE[lang],
+			url: pageUrl(lang, suffix),
+			title: `${project.title} — Case Study`,
+			description: project.description,
+			siteName: `${SITE_NAME} Portfolio`,
+			images: [{ url: project.cover || "/avatar.jpg", alt: project.title }],
+		},
+	};
 }
 
 export default async function Page({ params }: { params: { lang: string; slug: string } }) {
@@ -29,8 +54,28 @@ export default async function Page({ params }: { params: { lang: string; slug: s
 	if (!project || !project.hasCaseStudy) notFound();
 	const { ui } = await getDict(lang);
 	const blocks = await getProjectBlocks(project.id);
+	const suffix = `/case-studies/${project.slug}`;
+	const url = pageUrl(lang, suffix);
+	const articleLd = {
+		"@context": "https://schema.org",
+		"@type": "Article",
+		"@id": `${url}#article`,
+		mainEntityOfPage: url,
+		headline: `${project.title} — Case Study`,
+		description: project.description,
+		inLanguage: lang,
+		image: project.cover || `${SITE_URL}/avatar.jpg`,
+		keywords: project.tags.join(", "),
+		author: { "@type": "Person", "@id": PERSON_ID, name: "Xudoshukur Madrimov" },
+		publisher: {
+			"@type": "Person",
+			"@id": PERSON_ID,
+			name: "Xudoshukur Madrimov",
+		},
+	};
 	return (
 		<article className="relative mx-auto max-w-3xl px-5 pt-36 pb-24">
+			<JsonLd data={articleLd} />
 			<Reveal>
 				<Link href={`/${lang}/case-studies`} className="section-eyebrow">← {ui.caseStudiesTitle}</Link>
 			</Reveal>

--- a/src/app/[lang]/case-studies/page.tsx
+++ b/src/app/[lang]/case-studies/page.tsx
@@ -1,10 +1,36 @@
+import { Metadata } from "next";
 import Link from "next/link";
 import Reveal from "~/components/reveal/reveal";
 import { getDict } from "~/dict";
 import { getProjects } from "~/lib/notion";
 import { PropsWithParams, Lang } from "~/types";
+import { SITE_NAME, OG_LOCALE, alternates, pageUrl } from "~/lib/seo";
 
 export const revalidate = 300;
+
+const CS_DESC: Record<Lang, string> = {
+	uz: "Xudoshukur Madrimov ishlab chiqqan production tizimlari bo'yicha case study'lar — davlat, ta'lim, fintech va transport.",
+	ru: "Кейсы по production-системам, созданным Худошукуром Мадримовым — госсектор, образование, финтех и транспорт.",
+	en: "Case studies of production systems built by Xudoshukur Madrimov — government, education, fintech and transport.",
+};
+
+export async function generateMetadata({ params }: PropsWithParams): Promise<Metadata> {
+	const { ui } = await getDict(params.lang);
+	const suffix = "/case-studies";
+	return {
+		title: ui.caseStudiesTitle,
+		description: CS_DESC[params.lang],
+		alternates: alternates(params.lang, suffix),
+		openGraph: {
+			type: "website",
+			locale: OG_LOCALE[params.lang],
+			url: pageUrl(params.lang, suffix),
+			title: ui.caseStudiesTitle,
+			description: CS_DESC[params.lang],
+			siteName: `${SITE_NAME} Portfolio`,
+		},
+	};
+}
 
 export default async function CaseStudiesPage({ params }: PropsWithParams) {
 	const lang = params.lang as Lang;

--- a/src/app/[lang]/layout.tsx
+++ b/src/app/[lang]/layout.tsx
@@ -1,44 +1,57 @@
 import type { Metadata } from "next";
+import { notFound } from "next/navigation";
 import Aurora from "~/components/aurora/aurora";
 import Footer from "~/components/footer/footer";
 import Navbar from "~/components/navbar/navbar";
 import { getDict } from "~/dict";
 import { Lang } from "~/types";
+import { SITE_URL, SITE_NAME, OG_LOCALE, isLang } from "~/lib/seo";
 
-export const metadata: Metadata = {
-	metadataBase: new URL("https://www.madrimov.uz"),
-	title: "Madrimov Xudoshukur — Team Lead / Fullstack Developer",
-	description:
-		"Portfolio of Madrimov Xudoshukur — Team Lead and Fullstack developer building production products with React, Next.js, Node.js, Bun and TypeScript.",
-	manifest: "site.webmanifest",
-	openGraph: {
-		type: "website",
-		locale: "en_US",
-		url: "https://www.madrimov.uz",
-		siteName: "Madrimov Xudoshukur Portfolio",
-		images: [
-			{
-				url: "https://www.madrimov.uz/avatar.jpg",
-				alt: "Madrimov Xudoshukur Portfolio",
-			},
-		],
-	},
-	twitter: {
-		creatorId: "@madrimov_x",
-		site: "@madrimov_x",
-		card: "summary_large_image",
-	},
-	robots: {
-		index: true,
-		follow: true,
-		googleBot: {
+/**
+ * Til bo'yicha sayt-darajasidagi standart metadata.
+ * MUHIM: bu yerda `alternates`/canonical YO'Q — har sahifa o'zining
+ * canonical + hreflang'ini beradi (umumiy canonical butun saytni noto'g'ri
+ * canonicalizatsiya qilib, indeksdan chiqarib yuborardi).
+ * `openGraph.url` ham bu yerda yo'q — har sahifa o'zi beradi.
+ */
+export async function generateMetadata({
+	params,
+}: {
+	params: { lang: string };
+}): Promise<Metadata> {
+	if (!isLang(params.lang)) return {};
+	const { header, work } = await getDict(params.lang);
+	return {
+		metadataBase: new URL(SITE_URL),
+		title: {
+			default: `${header.name} — ${header.jobTitle}`,
+			template: `%s | ${SITE_NAME}`,
+		},
+		description: work.desc,
+		manifest: "site.webmanifest",
+		openGraph: {
+			type: "website",
+			locale: OG_LOCALE[params.lang],
+			siteName: `${SITE_NAME} Portfolio`,
+			images: [{ url: "/avatar.jpg", alt: `${SITE_NAME} Portfolio` }],
+		},
+		twitter: {
+			creatorId: "@madrimov_x",
+			site: "@madrimov_x",
+			card: "summary_large_image",
+		},
+		robots: {
 			index: true,
 			follow: true,
-			"max-image-preview": "large",
-			"max-snippet": -1,
+			googleBot: {
+				index: true,
+				follow: true,
+				"max-image-preview": "large",
+				"max-snippet": -1,
+			},
 		},
-	},
-};
+	};
+}
 
 export default async function RootLayout({
 	children,
@@ -49,6 +62,8 @@ export default async function RootLayout({
 	};
 	children: React.ReactNode;
 }>) {
+	// Yaroqsiz til — toza 404 (soft-404 / cheksiz URL fazosini oldini oladi).
+	if (!isLang(params.lang)) notFound();
 	const dict = await getDict(params.lang as Lang);
 	return (
 		<div className="flex min-h-full flex-col">

--- a/src/app/[lang]/page.tsx
+++ b/src/app/[lang]/page.tsx
@@ -1,4 +1,14 @@
 import { Metadata } from "next";
+import JsonLd from "~/components/json-ld/json-ld";
+import {
+	SITE_URL,
+	SITE_NAME,
+	OG_LOCALE,
+	PERSON_ID,
+	WEBSITE_ID,
+	alternates,
+	pageUrl,
+} from "~/lib/seo";
 import SignalEffects from "~/components/signal-effects/signal-effects";
 import StatusTicker from "~/components/status-ticker/status-ticker";
 import Experience from "~/components/experience/experience";
@@ -19,7 +29,7 @@ export async function generateMetadata({
 	const { header, work } = await getDict(params.lang);
 
 	return {
-		title: `${header.name} — ${header.jobTitle}`,
+		title: { absolute: `${header.name} — ${header.jobTitle}` },
 		description: work.desc,
 		creator: header.name,
 		keywords: [
@@ -34,34 +44,45 @@ export async function generateMetadata({
 			"Madrimov",
 			"Xudoshukur Madrimov",
 		],
-		manifest: "site.webmanifest",
+		alternates: alternates(params.lang, ""),
 		openGraph: {
 			type: "website",
-			locale: params.lang,
-			url: "https://www.madrimov.uz",
-			siteName: "Madrimov Xudoshukur Portfolio",
-			images: [
-				{
-					url: "https://www.madrimov.uz/avatar.jpg",
-					alt: "Madrimov Xudoshukur Portfolio",
-				},
-			],
-		},
-		twitter: {
-			creatorId: "@madrimov_x",
-			site: "@madrimov_x",
-			card: "summary_large_image",
-		},
-		robots: {
-			index: true,
-			follow: true,
+			locale: OG_LOCALE[params.lang],
+			url: pageUrl(params.lang, ""),
+			siteName: `${SITE_NAME} Portfolio`,
+			images: [{ url: "/avatar.jpg", alt: `${SITE_NAME} Portfolio` }],
 		},
 	};
 }
 
 export default async function Home({ params }: PropsWithParams) {
+	const { header } = await getDict(params.lang);
+	const personLd = {
+		"@context": "https://schema.org",
+		"@type": "Person",
+		"@id": PERSON_ID,
+		name: "Xudoshukur Madrimov",
+		alternateName: "Madrimov Xudoshukur",
+		url: SITE_URL,
+		image: `${SITE_URL}/avatar.jpg`,
+		jobTitle: header.jobTitle,
+		sameAs: [
+			"https://github.com/madrimovDev",
+			"https://t.me/madrimov",
+		],
+	};
+	const websiteLd = {
+		"@context": "https://schema.org",
+		"@type": "WebSite",
+		"@id": WEBSITE_ID,
+		url: SITE_URL,
+		name: SITE_NAME,
+		inLanguage: params.lang,
+		publisher: { "@id": PERSON_ID },
+	};
 	return (
 		<>
+			<JsonLd data={[personLd, websiteLd]} />
 			<SignalEffects />
 			<StatusTicker />
 			<Header lang={params.lang} />

--- a/src/app/[lang]/portfolio/layout.tsx
+++ b/src/app/[lang]/portfolio/layout.tsx
@@ -1,27 +1,37 @@
 import { Metadata } from "next";
 import { PropsWithChildren } from "react";
+import { getDict } from "~/dict";
+import { Lang } from "~/types";
+import { SITE_NAME, OG_LOCALE, alternates, pageUrl } from "~/lib/seo";
 
-export const metadata: Metadata = {
-	title: "Madrimov Xudoshukur — Projects",
-	description:
-		"Selected production projects by Madrimov Xudoshukur — fullstack platforms built with React, Next.js, Node.js, Bun, Electron and TypeScript.",
-	openGraph: {
-		type: "website",
-		url: "https://www.madrimov.uz/portfolio",
-		title: "Madrimov Xudoshukur — Projects",
-		description:
-			"Selected production projects by Madrimov Xudoshukur — fullstack platforms built with React, Next.js, Node.js, Bun, Electron and TypeScript.",
-		images: [
-			{
-				url: "https://www.madrimov.uz/avatar.jpg",
-				width: 800,
-				height: 600,
-				alt: "Madrimov Xudoshukur — Projects",
-			},
-		],
-		siteName: "Madrimov Xudoshukur Portfolio",
-	},
+const PORT_DESC: Record<Lang, string> = {
+	uz: "Madrimov Xudoshukur tomonidan ishlab chiqilgan production loyihalari — React, Next.js, Node.js, Bun va Electron bilan.",
+	ru: "Production-проекты Худошукура Мадримова — на React, Next.js, Node.js, Bun и Electron.",
+	en: "Production projects by Madrimov Xudoshukur — built with React, Next.js, Node.js, Bun and Electron.",
 };
+
+export async function generateMetadata({
+	params,
+}: {
+	params: { lang: Lang };
+}): Promise<Metadata> {
+	const { portfolio } = await getDict(params.lang);
+	const suffix = "/portfolio";
+	return {
+		title: portfolio.title,
+		description: PORT_DESC[params.lang],
+		alternates: alternates(params.lang, suffix),
+		openGraph: {
+			type: "website",
+			locale: OG_LOCALE[params.lang],
+			url: pageUrl(params.lang, suffix),
+			title: portfolio.title,
+			description: PORT_DESC[params.lang],
+			siteName: `${SITE_NAME} Portfolio`,
+			images: [{ url: "/avatar.jpg", alt: portfolio.title }],
+		},
+	};
+}
 
 export default function Layout({ children }: PropsWithChildren) {
 	return <>{children}</>;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,8 @@
 import { Unbounded, Golos_Text, JetBrains_Mono } from "next/font/google";
+import { headers } from "next/headers";
 import "./globals.css";
 import { Analytics } from "@vercel/analytics/react";
+import { DEFAULT_LOCALE, isLang } from "~/lib/seo";
 
 const display = Unbounded({
 	subsets: ["latin"],
@@ -31,9 +33,11 @@ export default async function RootLayout({
 	};
 	children: React.ReactNode;
 }>) {
+	const headerLocale = headers().get("x-locale");
+	const lang = headerLocale && isLang(headerLocale) ? headerLocale : DEFAULT_LOCALE;
 	return (
 		<html
-			lang="en"
+			lang={lang}
 			className={`h-full ${display.variable} ${sans.variable} ${mono.variable}`}
 		>
 			<body className="font-sans bg-night text-fg antialiased">

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,13 @@
+import { MetadataRoute } from "next";
+import { SITE_URL } from "~/lib/seo";
+
+export default function robots(): MetadataRoute.Robots {
+	return {
+		rules: {
+			userAgent: "*",
+			allow: "/",
+		},
+		sitemap: `${SITE_URL}/sitemap.xml`,
+		host: SITE_URL,
+	};
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,37 @@
+import { MetadataRoute } from "next";
+import { getPublishedPosts, getProjects } from "~/lib/notion";
+import { SITE_URL, LOCALES } from "~/lib/seo";
+
+export const revalidate = 300;
+
+/**
+ * Dinamik sitemap — barcha statik sahifalar + Notion'dagi bloglar va
+ * case-study'lar, uchala til uchun. hreflang har sahifaning <head>'ida
+ * (metadata.alternates) beriladi — Google uchun shu yetarli.
+ */
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+	const posts = await getPublishedPosts("uz"); // uz fallback -> barcha noyob slug'lar
+	const caseStudies = (await getProjects("uz")).filter((p) => p.hasCaseStudy);
+
+	const entries: MetadataRoute.Sitemap = [];
+
+	const push = (suffix: string, lastModified?: string) => {
+		for (const lang of LOCALES) {
+			entries.push({
+				url: `${SITE_URL}/${lang}${suffix}`,
+				...(lastModified ? { lastModified: new Date(lastModified) } : {}),
+			});
+		}
+	};
+
+	// Statik sahifalar
+	for (const s of ["", "/blog", "/case-studies", "/portfolio"]) push(s);
+
+	// Bloglar
+	for (const p of posts) push(`/blog/${p.slug}`, p.date);
+
+	// Case-study'lar
+	for (const c of caseStudies) push(`/case-studies/${c.slug}`);
+
+	return entries;
+}

--- a/src/components/json-ld/json-ld.tsx
+++ b/src/components/json-ld/json-ld.tsx
@@ -1,0 +1,18 @@
+/**
+ * JSON-LD strukturali ma'lumotни <script type="application/ld+json"> sifatida
+ * render qiladi. `data` bitta obyekt yoki obyektlar massivi bo'lishi mumkin.
+ */
+export default function JsonLd({ data }: { data: object | object[] }) {
+	const items = Array.isArray(data) ? data : [data];
+	return (
+		<>
+			{items.map((item, i) => (
+				<script
+					key={i}
+					type="application/ld+json"
+					dangerouslySetInnerHTML={{ __html: JSON.stringify(item) }}
+				/>
+			))}
+		</>
+	);
+}

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,0 +1,41 @@
+import { Lang } from "~/types";
+
+/** Bitta canonical host — www'siz (foydalanuvchi tanlovi). */
+export const SITE_URL = "https://madrimov.uz";
+export const LOCALES: Lang[] = ["uz", "ru", "en"];
+export const DEFAULT_LOCALE: Lang = "uz";
+export const SITE_NAME = "Madrimov Xudoshukur";
+export const PERSON_ID = `${SITE_URL}/#person`;
+export const WEBSITE_ID = `${SITE_URL}/#website`;
+
+/** OpenGraph locale kodlari (og:locale uchun). */
+export const OG_LOCALE: Record<Lang, string> = {
+	uz: "uz_UZ",
+	ru: "ru_RU",
+	en: "en_US",
+};
+
+export function isLang(x: string): x is Lang {
+	return (LOCALES as string[]).includes(x);
+}
+
+/** hreflang languages xaritasi — suffix lang prefiksisiz bo'lishi kerak (masalan "" yoki "/blog/x"). */
+export function altLanguages(suffix: string): Record<string, string> {
+	const languages: Record<string, string> = {};
+	for (const l of LOCALES) languages[l] = `${SITE_URL}/${l}${suffix}`;
+	languages["x-default"] = `${SITE_URL}/${DEFAULT_LOCALE}${suffix}`;
+	return languages;
+}
+
+/** Har sahifaning canonical + hreflang alternates obyekti. Layout'da EMAS, faqat sahifada. */
+export function alternates(lang: Lang, suffix: string) {
+	return {
+		canonical: `${SITE_URL}/${lang}${suffix}`,
+		languages: altLanguages(suffix),
+	};
+}
+
+/** To'liq sahifa URL (og:url uchun). */
+export function pageUrl(lang: Lang, suffix: string): string {
+	return `${SITE_URL}/${lang}${suffix}`;
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,6 @@
 import { match } from "@formatjs/intl-localematcher";
 import Negotiator from "negotiator";
-import { NextRequest } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 
 let headers = { "accept-language": "en-US,en;q=0.5" };
 let languages = new Negotiator({ headers }).languages();
@@ -36,11 +36,17 @@ function getLocale(request: NextRequest) {
 export function middleware(request: NextRequest) {
 	// Check if there is any supported locale in the pathname
 	const { pathname } = request.nextUrl;
-	const pathnameHasLocale = locales.some(
+	const activeLocale = locales.find(
 		(locale) => pathname.startsWith(`/${locale}/`) || pathname === `/${locale}`
 	);
 
-	if (pathnameHasLocale) return;
+	// Locale allaqachon bor — root layout <html lang> ni o'qishi uchun
+	// so'rov headeriga lokalni qo'shib o'tkazamiz.
+	if (activeLocale) {
+		const requestHeaders = new Headers(request.headers);
+		requestHeaders.set("x-locale", activeLocale);
+		return NextResponse.next({ request: { headers: requestHeaders } });
+	}
 
 	// Redirect if there is no locale
 	const locale = getLocale(request);


### PR DESCRIPTION
## Maqsad
madrimov.uz SEO'sini ideal holatga keltirish, bloglar ham to'liq SEO bo'lishi.
Canonical host: **non-www (madrimov.uz)**.

## Tuzatildi (audit topilmalari bo'yicha)
🔴 **Jiddiy**
- `sitemap.xml` — endi haqiqiy dinamik sitemap (avval app sahifasi qaytarardi).
- `robots.txt` — endi haqiqiy (avval app sahifasi).
- **Canonical** — har sahifada o'ziga ishora qiluvchi canonical.
- **hreflang** — uz/ru/en + x-default har sahifada.
- **www/non-www** — metadataBase non-www; (www→non-www 301 — Vercel tomonida, pastga qarang).

🟠 **O'rta**
- `og:url` endi har sahifaning o'z manzili (avval hammasi bosh sahifa edi).
- `og:locale` til bo'yicha to'g'ri (uz_UZ/ru_RU/en_US; avval en_US edi).
- Blog: `og:type=article` + publishedTime/author + **JSON-LD BlogPosting** (inLanguage, author/publisher Person'ga bog'langan).
- Case study: og article + JSON-LD Article. Bosh sahifa: Person + WebSite JSON-LD.
- `<html lang>` endi til bo'yicha to'g'ri (uz/ru/en; avval qattiq "en").

🟡 **Yengil**
- Blog/case-studies/portfolio ro'yxatlari uchun lokalizatsiyalangan metadata.
- Yaroqsiz til segmentlari `notFound()` (oddiy yaroqsiz yo'llar to'g'ri 404).

## Tekshirildi (lokal `next start`)
- `<html lang>`: /uz→uz, /ru→ru, /en→en ✅
- robots.txt va sitemap.xml — haqiqiy mazmun ✅
- Blog post: canonical (o'ziga), hreflang (4), og:url/locale/type to'g'ri, JSON-LD BlogPosting ✅
- Bosh sahifa: Person + WebSite JSON-LD, canonical ✅
- og:image absolyut (metadataBase) ✅
- `next build` EXIT 0

## Qoladi (Vercel tomonida — kod emas)
- **www → non-www 301 redirect**: Vercel dashboard → Domains. Hozir ikkala host ham 200 qaytaradi; canonical teglar Google'ni to'g'rilaydi, lekin "ideal" uchun 301 kerak.
- (Ixtiyoriy) `/foo.bar` kabi nuqtaли soxta yo'llar 404 sahifasini ko'rsatadi, lekin HTTP 200 (Next catch-all xususiyati; amaliy ta'sir ~nol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)