### PR TITLE
feat(rss): RSS feed

### DIFF
--- a/src/app/[lang]/rss.xml/route.ts
+++ b/src/app/[lang]/rss.xml/route.ts
@@ -1,0 +1,46 @@
+import { getPublishedPosts } from "~/lib/notion";
+import { SITE_URL, SITE_NAME, isLang } from "~/lib/seo";
+
+export const revalidate = 300;
+
+/** RSS matnida xavfli belgilarni qochirish. */
+function esc(s: string): string {
+	return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+export async function GET(
+	_req: Request,
+	{ params }: { params: { lang: string } }
+) {
+	if (!isLang(params.lang)) return new Response("Not found", { status: 404 });
+	const lang = params.lang;
+	const posts = await getPublishedPosts(lang);
+
+	const items = posts
+		.map((p) => {
+			const url = `${SITE_URL}/${lang}/blog/${p.slug}`;
+			return `\t\t<item>
+\t\t\t<title>${esc(p.title)}</title>
+\t\t\t<link>${url}</link>
+\t\t\t<guid>${url}</guid>
+\t\t\t<description>${esc(p.description)}</description>
+\t\t\t<pubDate>${new Date(p.date).toUTCString()}</pubDate>
+\t\t</item>`;
+		})
+		.join("\n");
+
+	const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+\t<channel>
+\t\t<title>${esc(SITE_NAME)} — Blog</title>
+\t\t<link>${SITE_URL}/${lang}/blog</link>
+\t\t<description>Muhandislik maqolalari — backend, arxitektura, DevOps</description>
+\t\t<language>${lang}</language>
+${items}
+\t</channel>
+</rss>`;
+
+	return new Response(xml, {
+		headers: { "Content-Type": "application/rss+xml; charset=utf-8" },
+	});
+}

--- a/src/app/rss.xml/route.ts
+++ b/src/app/rss.xml/route.ts
@@ -1,0 +1,6 @@
+import { SITE_URL, DEFAULT_LOCALE } from "~/lib/seo";
+
+/** /rss.xml → mahalliy-birinchi: /uz/rss.xml (middleware nuqtali yo'llarni o'tkazib yuboradi). */
+export function GET() {
+	return Response.redirect(`${SITE_URL}/${DEFAULT_LOCALE}/rss.xml`, 308);
+}

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -27,11 +27,12 @@ export function altLanguages(suffix: string): Record<string, string> {
 	return languages;
 }
 
-/** Har sahifaning canonical + hreflang alternates obyekti. Layout'da EMAS, faqat sahifada. */
+/** Har sahifaning canonical + hreflang + RSS alternates obyekti. Layout'da EMAS, faqat sahifada. */
 export function alternates(lang: Lang, suffix: string) {
 	return {
 		canonical: `${SITE_URL}/${lang}${suffix}`,
 		languages: altLanguages(suffix),
+		types: { "application/rss+xml": `${SITE_URL}/${lang}/rss.xml` },
 	};
 }
 


### PR DESCRIPTION
/uz|ru|en/rss.xml (ISR 300s), /rss.xml→/uz/rss.xml, sahifa head'ida alternate havola.

🤖 Generated with [Claude Code](https://claude.com/claude-code)